### PR TITLE
dodatak za povezivanje sa backendom

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  frontend:
+    container_name: frontend
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "${FRONTEND_PORT:-3000}:80"
+    networks: [banka]
+
+networks:
+  banka:
+    name: banka-net
+    external: true

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html;
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
Samo kontejnerizacija frontenda u Dockerfile, i docker-compose sa networkom "banka"

Sa ovom konfiguracijom, mogu da se otvore i da se run-uju oba (prvo backend koj emituje network, a onda i frontend koj se kaci na tu istu mrezu)

Ako je potrebno, mogu i neki README.md ukratko da prilozim sa tim kako se pokrece container, uglavnom je potrebno da samo pullujete oba repo-a, pokrenete backend sa `make all` i onda pokrenete frontend sa `docker-compose up -d`

Potrebno je odrzavati posebne .env varijable za kontaktiranje backenda u odnosu na local development sa `npm dev run`, jer umesto da se gadja localhost:xxxx/nekiApi, gadjao bi se gateway:xxxx/nekiApi. ali otom potom