### PR TITLE
fix: account details koristi accountNumber (#107)

### DIFF
--- a/src/pages/AccountDetailsPage.jsx
+++ b/src/pages/AccountDetailsPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { getAccountById, getAccountTransactions } from "../services/AccountService";
+import { getAccountByNumber, getAccountTransactions } from "../services/AccountService";
 import Sidebar from "../components/Sidebar.jsx";
 import "./AccountDetailsPage.css";
 
@@ -18,7 +18,7 @@ function fmt(amount, currency = "RSD") {
 }
 
 export default function AccountDetailsPage() {
-    const { id } = useParams(); // 'id' je string broj računa iz URL-a
+    const { accountNumber } = useParams(); // 'id' je string broj računa iz URL-a
     const navigate = useNavigate();
 
     const [account, setAccount] = useState(null);
@@ -27,15 +27,15 @@ export default function AccountDetailsPage() {
     const [error, setError] = useState("");
 
     useEffect(() => {
-        if (!id) return; 
+        if (!accountNumber) return;
         let cancelled = false;
 
         const load = async () => {
             try {
                 // BITNO: id (broj računa) šaljemo kao string da ne izgubimo preciznost
                 const [acc, txs] = await Promise.all([
-                    getAccountById(id),           
-                    getAccountTransactions(id), 
+                    getAccountByNumber(accountNumber),
+                    getAccountTransactions(accountNumber),
                 ]);
                 
                 if (!cancelled) {
@@ -53,7 +53,7 @@ export default function AccountDetailsPage() {
 
         load();
         return () => { cancelled = true; };
-    }, [id]);
+    }, [accountNumber]);
 
     if (loading) {
         return (

--- a/src/router/AppRouter.jsx
+++ b/src/router/AppRouter.jsx
@@ -69,7 +69,7 @@ export default function AppRouter() {
           <Route path="/verify" element={<ProtectedRoute requiredRole="client"><TotpSetupPage /></ProtectedRoute>} />
           <Route path="/transfer" element={<ProtectedRoute requiredRole="client"><TransferPage /></ProtectedRoute>} />
 
-          <Route path="/accounts/:id" element={<ProtectedRoute requiredRole="client"><AccountDetailsPage /></ProtectedRoute>} />
+          <Route path="/accounts/:accountNumber" element={<ProtectedRoute requiredRole="client"><AccountDetailsPage /></ProtectedRoute>} />
           <Route path="/exchange" element={<ProtectedRoute requiredRole="client"><ExchangePage /></ProtectedRoute>} />
           <Route path="/berza" element={<ProtectedRoute requiredRole="employee"><BerzaPage /></ProtectedRoute>} />
 

--- a/src/services/AccountService.js
+++ b/src/services/AccountService.js
@@ -8,11 +8,6 @@ export async function getAccounts() {
     return response.data;
 }
 
-export async function getAccountById(accountNumber) {
-  // accountNumber ovde treba da bude "333000112345678910"
-  const response = await api.get(`/accounts/${accountNumber}`);
-  return response.data;
-}
 
 export async function getAccountTransactions(accountNumber) {
   try {


### PR DESCRIPTION
- ruta za client account details koristi `accountNumber` umesto `id`
- `AccountDetailsPage` koristi `useParams().accountNumber`
- account details poziv koristi broj računa
- transakcije za račun se takođe dohvaćaju preko broja računa
- očišćen `AccountService` i uklonjen duplikat funkcije