### PR TITLE
Restrict employee creation to admins only (Scenario 16)

### DIFF
--- a/src/pages/CreateEmployeePage.jsx
+++ b/src/pages/CreateEmployeePage.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { createEmployee, updateEmployee, getEmployees } from "../services/EmployeeService";
 import { PERMISSIONS } from "../constants/permissions";
 import "./CreateEmployeePage.css";
@@ -62,6 +62,17 @@ export default function CreateEmployeePage() {
   const [successMsg, setSuccessMsg] = useState("");
   const [loading, setLoading] = useState(false);
 
+  const permissions = JSON.parse(localStorage.getItem("permissions") || "[]");
+  const isAdmin = permissions.includes("admin");
+
+  useEffect(() => {
+    if (!isAdmin) {
+      navigate("/employees", { replace: true });
+    }
+  }, [isAdmin, navigate]);
+
+  if (!isAdmin) return null;
+
   function handlePermissionToggle(value) {
     setForm((prev) => ({
       ...prev,
@@ -122,6 +133,10 @@ export default function CreateEmployeePage() {
 
           if (!created) throw new Error("Nije moguće pronaći kreiranog zaposlenog.");
 
+          const safePermissions = isAdmin
+              ? form.permissions
+              : form.permissions.filter((permission) => permission !== "admin");
+
           await updateEmployee(created.id, {
             firstName: form.ime,
             lastName: form.prezime,
@@ -131,7 +146,7 @@ export default function CreateEmployeePage() {
             position: form.pozicija,
             department: form.department,
             active: true,
-            permissions: form.permissions,
+            permissions: safePermissions,
           });
         } catch {
           setSuccessMsg(

--- a/src/pages/EmployeesPage.jsx
+++ b/src/pages/EmployeesPage.jsx
@@ -13,6 +13,9 @@ function EmployeesPage() {
   const [error, setError] = useState("");
   const navigate = useNavigate();
 
+  const permissions = JSON.parse(localStorage.getItem("permissions") || "[]");
+  const isAdmin = permissions.includes("admin");
+
   useEffect(() => {
     const controller = new AbortController();
 
@@ -100,9 +103,11 @@ function EmployeesPage() {
                 </p>
               </div>
 
-              <button className="add-btn" onClick={openCreateEmployee}>
-                + Dodaj zaposlenog
-              </button>
+              {isAdmin && (
+                  <button className="add-btn" onClick={openCreateEmployee}>
+                    + Dodaj zaposlenog
+                  </button>
+              )}
             </div>
 
             <div className="employee-toolbar">

--- a/src/router/AppRouter.jsx
+++ b/src/router/AppRouter.jsx
@@ -57,7 +57,7 @@ export default function AppRouter() {
           <Route path="/clients" element={<ProtectedRoute requiredRole="employee"><ClientsPage /></ProtectedRoute>} />
           <Route path="/clients/:id" element={<ProtectedRoute requiredRole="employee"><ClientDetailsPage /></ProtectedRoute>} />
 
-          <Route path="/employees/create" element={<ProtectedRoute requiredRole="employee"><CreateEmployeePage /></ProtectedRoute>} />
+          <Route path="/employees/create" element={<ProtectedRoute requiredRole="employee" requiredPermission="admin"><CreateEmployeePage /></ProtectedRoute>}/>
           <Route path="/employees/edit/:id" element={<ProtectedRoute requiredRole="employee"><EditEmployeePage /></ProtectedRoute>} />
           <Route path="/employees/:id" element={<ProtectedRoute requiredRole="employee"><EmployeeDetailsPage /></ProtectedRoute>} />
           <Route path="/recipients" element={<ProtectedRoute requiredRole="client"><RecipientsPage /></ProtectedRoute>} />

--- a/src/router/ProtectedRoute.jsx
+++ b/src/router/ProtectedRoute.jsx
@@ -1,14 +1,29 @@
 import { Navigate } from "react-router-dom";
 
-export default function ProtectedRoute({ children, requiredRole }) {
+export default function ProtectedRoute({ children, requiredRole, requiredPermission }) {
   const token = localStorage.getItem("accessToken");
   if (!token) {
     return <Navigate to="/login" replace />;
   }
 
-  if (requiredRole) {
-    const userRole = localStorage.getItem("userRole");
-    if (userRole && userRole !== requiredRole) {
+  const userRole = localStorage.getItem("userRole");
+
+  if (requiredRole && userRole && userRole !== requiredRole) {
+    if (userRole === "client") {
+      return <Navigate to="/dashboard" replace />;
+    }
+    return <Navigate to="/employees" replace />;
+  }
+
+  if (requiredPermission) {
+    let permissions = [];
+    try {
+      permissions = JSON.parse(localStorage.getItem("permissions") || "[]");
+    } catch {
+      permissions = [];
+    }
+
+    if (!permissions.includes(requiredPermission)) {
       if (userRole === "client") {
         return <Navigate to="/dashboard" replace />;
       }


### PR DESCRIPTION
- Restricted access to employee creation page to admin users only
- Added permission-based route protection
- Hid create employee action for non-admin users
- Secured admin role assignment during employee creation

Closes #132 