### PR TITLE
feat: wire TaxService to real /api/tax endpoints

### DIFF
--- a/src/pages/TaxDashboardPage.jsx
+++ b/src/pages/TaxDashboardPage.jsx
@@ -40,8 +40,7 @@ function TaxDashboardPage() {
       const searchLower = searchTerm.toLowerCase();
       const matchesSearch =
         (item.firstName || "").toLowerCase().includes(searchLower) ||
-        (item.lastName || "").toLowerCase().includes(searchLower) ||
-        (item.email || "").toLowerCase().includes(searchLower);
+        (item.lastName || "").toLowerCase().includes(searchLower);
 
       const matchesRole = !filterRole || item.role === filterRole;
 
@@ -134,7 +133,7 @@ function TaxDashboardPage() {
                 </span>
                 <input
                   className="search"
-                  placeholder="Pretraga po imenu, prezimenu ili email-u"
+                  placeholder="Pretraga po imenu ili prezimenu"
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
                 />
@@ -175,7 +174,6 @@ function TaxDashboardPage() {
                     <tr>
                       <th>Ime</th>
                       <th>Prezime</th>
-                      <th>Email</th>
                       <th>Tip</th>
                       <th className="amount-header">Iznos poreza (RSD)</th>
                     </tr>
@@ -185,7 +183,6 @@ function TaxDashboardPage() {
                       <tr key={item.id}>
                         <td>{item.firstName}</td>
                         <td>{item.lastName}</td>
-                        <td className="email-cell">{item.email}</td>
                         <td>
                           <span className={`role-badge role-${item.role}`}>
                             {roleLabel[item.role] || item.role}

--- a/src/services/TaxService.js
+++ b/src/services/TaxService.js
@@ -1,30 +1,17 @@
 import api from "./api";
 
-// TODO: Replace with real endpoint when backend implements Celina 3 (berza)
-// Expected endpoints: GET /api/tax, POST /api/tax/collect
-const MOCK_TAX_DATA = [
-  { id: 1, firstName: "Marko", lastName: "Petrović", email: "marko.petrovic@example.com", role: "client", taxAmount: 45230.0 },
-  { id: 2, firstName: "Ana", lastName: "Jovanović", email: "ana.jovanovic@example.com", role: "client", taxAmount: 12750.5 },
-  { id: 3, firstName: "Nikola", lastName: "Đorđević", email: "nikola.djordjevic@example.com", role: "actuary", taxAmount: 89100.0 },
-  { id: 4, firstName: "Jelena", lastName: "Nikolić", email: "jelena.nikolic@example.com", role: "client", taxAmount: 3200.0 },
-  { id: 5, firstName: "Stefan", lastName: "Milošević", email: "stefan.milosevic@example.com", role: "actuary", taxAmount: 67450.75 },
-  { id: 6, firstName: "Milica", lastName: "Stanković", email: "milica.stankovic@example.com", role: "client", taxAmount: 21890.25 },
-  { id: 7, firstName: "Lazar", lastName: "Ilić", email: "lazar.ilic@example.com", role: "actuary", taxAmount: 154320.0 },
-  { id: 8, firstName: "Tamara", lastName: "Popović", email: "tamara.popovic@example.com", role: "client", taxAmount: 8640.0 },
-];
-
 export async function getTaxData() {
-  // const response = await api.get("/tax");
-  // return response.data;
-  return new Promise((resolve) => {
-    setTimeout(() => resolve(MOCK_TAX_DATA), 500);
-  });
+  const response = await api.get("/tax/debts");
+  return (response.data || []).map((d) => ({
+    id: d.user_id,
+    firstName: d.first_name,
+    lastName: d.last_name,
+    role: d.team,
+    taxAmount: d.unpaid_rsd,
+  }));
 }
 
 export async function triggerTaxCollection() {
-  // const response = await api.post("/tax/collect");
-  // return response.data;
-  return new Promise((resolve) => {
-    setTimeout(() => resolve({ message: "Obračun poreza uspešno pokrenut." }), 1000);
-  });
+  const response = await api.post("/tax/run");
+  return response.data;
 }


### PR DESCRIPTION
## Summary
- Replace `TaxService.js` mocks with real calls: `getTaxData` → `GET /api/tax/debts`, `triggerTaxCollection` → `POST /api/tax/run`. Map backend fields (`user_id`, `first_name`, `last_name`, `team`, `unpaid_rsd`) to the shape the page already consumes.
- Drop the email column and email-search from `TaxDashboardPage`, since `/tax/debts` does not return email.

## Test plan
- [ ] Log in as supervisor, open `/tax` — table loads from `/api/tax/debts` with real users
- [ ] Role filter (Klijenti/Aktuari) narrows the list correctly
- [ ] Name search filters by first/last name only
- [ ] "Pokreni obračun poreza" hits `POST /api/tax/run` and reflects updated debts on reload

Note: the cypress spec `tax-tracking.cy.js` is currently `describe.skip` pending a full rewrite against `TaxDashboardPage`; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)