### PR TITLE
feat: wire SecurityDetailService to real backend

### DIFF
--- a/src/hooks/useSecurityDetails.js
+++ b/src/hooks/useSecurityDetails.js
@@ -10,41 +10,49 @@ export function useSecurityDetails(ticker) {
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    loadDetail();
+    let cancelled = false;
+    const load = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const data = await getSecurityDetail(ticker);
+        if (cancelled) return;
+        setDetail(data);
+
+        if (data.type === "stock" && data.stockId) {
+          const optionsData = await getSecurityOptions(data.stockId);
+          if (!cancelled) setOptions(optionsData);
+        } else {
+          if (!cancelled) setOptions([]);
+        }
+      } catch (err) {
+        if (!cancelled) setError(err.message);
+        console.error(err);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
   }, [ticker]);
 
   useEffect(() => {
-    loadHistory();
-  }, [ticker, period]);
-
-  const loadDetail = async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      
-      const data = await getSecurityDetail(ticker);
-      setDetail(data);
-      
-      if (data.type === "stock" || ticker.match(/^[A-Z]{1,5}$/)) {
-        const optionsData = await getSecurityOptions(ticker);
-        setOptions(optionsData);
-      }
-    } catch (err) {
-      setError(err.message);
-      console.error(err);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const loadHistory = async () => {
-    try {
-      const data = await getSecurityHistory(ticker, period);
-      setHistory(data);
-    } catch (err) {
-      console.error(err);
-    }
-  };
+    if (!detail?.id) return;
+    let cancelled = false;
+    getSecurityHistory(detail.id, period)
+      .then((data) => {
+        if (!cancelled) setHistory(data);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [detail?.id, period]);
 
   return {
     detail,

--- a/src/services/SecurityDetailService.js
+++ b/src/services/SecurityDetailService.js
@@ -1,95 +1,115 @@
-// za sad mock podaci
-const mockHistoryData = {
-  AAPL: [
-    { date: "2024-03-17", price: 148.50, high: 149.00, low: 148.00, volume: 50000000 },
-    { date: "2024-03-18", price: 149.00, high: 150.00, low: 148.50, volume: 52000000 },
-    { date: "2024-03-19", price: 150.25, high: 151.00, low: 149.50, volume: 48000000 },
-    { date: "2024-03-20", price: 150.15, high: 151.50, low: 150.00, volume: 55000000 },
-    { date: "2024-03-21", price: 150.50, high: 151.00, low: 149.80, volume: 51000000 },
-    { date: "2024-03-22", price: 149.80, high: 150.50, low: 149.00, volume: 49000000 },
-  ],
-  MSFT: [
-    { date: "2024-03-17", price: 318.00, high: 319.00, low: 317.50, volume: 25000000 },
-    { date: "2024-03-18", price: 319.50, high: 320.00, low: 318.50, volume: 26000000 },
-    { date: "2024-03-19", price: 320.15, high: 321.00, low: 319.00, volume: 24000000 },
-    { date: "2024-03-20", price: 319.80, high: 320.50, low: 319.00, volume: 27000000 },
-    { date: "2024-03-21", price: 320.50, high: 321.00, low: 319.50, volume: 25000000 },
-    { date: "2024-03-22", price: 319.90, high: 320.50, low: 319.00, volume: 26000000 },
-  ],
+import api from "./api";
+
+const CENTS = 100;
+
+const PERIOD_MAP = {
+  "1D": "day",
+  "1W": "week",
+  "1M": "month",
+  "1Y": "year",
+  "5Y": "5y",
 };
 
-const mockOptions = {
-  AAPL: [
-    {
-      settlementDate: "2024-04-20",
-      daysToExpiry: 28,
-      options: [
-        { strike: 140, callLast: 10.50, callTheta: -0.05, callBid: 10.25, callAsk: 10.75, callVol: 150, callOI: 5000, putLast: 0.01, putTheta: -0.01, putBid: 0.01, putAsk: 0.05, putVol: 100, putOI: 500 },
-        { strike: 145, callLast: 8.75, callTheta: -0.04, callBid: 8.50, callAsk: 9.00, callVol: 200, callOI: 6000, putLast: 0.05, putTheta: -0.02, putBid: 0.03, putAsk: 0.08, putVol: 120, putOI: 600 },
-        { strike: 150, callLast: 6.25, callTheta: -0.03, callBid: 6.00, callAsk: 6.50, callVol: 300, callOI: 8000, putLast: 0.25, putTheta: -0.03, putBid: 0.20, putAsk: 0.30, putVol: 150, putOI: 800 },
-        { strike: 155, callLast: 4.00, callTheta: -0.02, callBid: 3.75, callAsk: 4.25, callVol: 250, callOI: 7000, putLast: 1.50, putTheta: -0.04, putBid: 1.40, putAsk: 1.60, putVol: 180, putOI: 1000 },
-        { strike: 160, callLast: 2.10, callTheta: -0.01, callBid: 1.90, callAsk: 2.30, callVol: 180, callOI: 5000, putLast: 4.00, putTheta: -0.05, putBid: 3.85, putAsk: 4.15, putVol: 200, putOI: 1200 },
-      ]
-    },
-    {
-      settlementDate: "2024-05-18",
-      daysToExpiry: 56,
-      options: [
-        { strike: 145, callLast: 9.50, callTheta: -0.03, callBid: 9.25, callAsk: 9.75, callVol: 100, callOI: 3000, putLast: 0.10, putTheta: -0.01, putBid: 0.08, putAsk: 0.12, putVol: 80, putOI: 400 },
-        { strike: 150, callLast: 7.25, callTheta: -0.02, callBid: 7.00, callAsk: 7.50, callVol: 150, callOI: 4000, putLast: 0.50, putTheta: -0.02, putBid: 0.45, putAsk: 0.55, putVol: 100, putOI: 600 },
-        { strike: 155, callLast: 5.10, callTheta: -0.02, callBid: 4.85, callAsk: 5.35, callVol: 120, callOI: 3500, putLast: 1.80, putTheta: -0.03, putBid: 1.70, putAsk: 1.90, putVol: 110, putOI: 700 },
-      ]
-    },
-  ],
-};
+function unixToISODate(sec) {
+  if (!sec) return "";
+  return new Date(sec * 1000).toISOString().slice(0, 10);
+}
+
+function daysBetween(fromUnix, toUnix) {
+  const ms = (toUnix - fromUnix) * 1000;
+  return Math.max(0, Math.round(ms / (1000 * 60 * 60 * 24)));
+}
+
+async function findListingByTicker(ticker) {
+  const { data } = await api.get("/listings", { params: { search: ticker } });
+  const listings = Array.isArray(data) ? data : [];
+  const match = listings.find((l) => l.ticker === ticker) || listings[0];
+  if (!match) {
+    throw new Error(`Hartija ${ticker} nije pronađena`);
+  }
+  return match;
+}
+
+function mapListingToDetail(l) {
+  return {
+    id: l.id,
+    stockId: l.stock_id || 0,
+    ticker: l.ticker,
+    name: l.name,
+    type: l.security_type === "future" ? "futures" : l.security_type,
+    price: (l.price ?? 0) / CENTS,
+    ask: (l.ask_price ?? 0) / CENTS,
+    bid: (l.bid_price ?? 0) / CENTS,
+    change: (l.change ?? 0) / CENTS,
+    volume: l.volume ?? 0,
+    exchange: l.exchange_acronym || "",
+  };
+}
 
 export async function getSecurityDetail(ticker) {
-  try {
-    console.log(`Mock: Dohvatanje detalja za ${ticker}...`);
-    await new Promise(resolve => setTimeout(resolve, 800));
-    
+  const listing = await findListingByTicker(ticker);
+  const { data } = await api.get(`/listings/${listing.id}`);
+  return mapListingToDetail(data);
+}
+
+export async function getSecurityHistory(listingId, period = "1M") {
+  if (!listingId) return [];
+  const backendPeriod = PERIOD_MAP[period] || "month";
+  const { data } = await api.get(`/listings/${listingId}/history`, {
+    params: { period: backendPeriod },
+  });
+  const points = data?.points || [];
+  return points.map((p) => {
+    const price = (p.price ?? 0) / CENTS;
+    const ask = (p.ask_price ?? 0) / CENTS;
+    const bid = (p.bid_price ?? 0) / CENTS;
     return {
-      ticker,
-      name: `${ticker} Company`,
-      price: 150.25,
-      ask: 150.50,
-      bid: 150.00,
-      change: 2.50,
-      volume: 50000000,
-      exchange: "NASDAQ",
+      date: unixToISODate(p.date),
+      price,
+      high: Math.max(price, ask, bid),
+      low: Math.min(price, ask || price, bid || price),
+      volume: p.volume ?? 0,
     };
-  } catch (error) {
-    console.error(`❌ Mock: Greška pri dohvatanju ${ticker}:`, error);
-    throw error;
-  }
+  });
 }
 
-export async function getSecurityHistory(ticker, period = "1M") {
-  try {
-    console.log(`Mock: Dohvatanje istorije za ${ticker} (${period})...`);
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    
-    const history = mockHistoryData[ticker] || [];
-    console.log(`Mock: Istorija za ${ticker}:`, history);
-    
-    return history;
-  } catch (error) {
-    console.error(`❌ Mock: Greška pri dohvatanju istorije:`, error);
-    throw error;
-  }
-}
+export async function getSecurityOptions(stockId) {
+  if (!stockId) return [];
+  const { data: dates } = await api.get(`/stocks/${stockId}/options/dates`);
+  const dateList = Array.isArray(dates) ? dates : [];
+  if (dateList.length === 0) return [];
 
-export async function getSecurityOptions(ticker) {
-  try {
-    console.log(`Mock: Dohvatanje opcija za ${ticker}...`);
-    await new Promise(resolve => setTimeout(resolve, 800));
-    
-    const options = mockOptions[ticker] || [];
-    console.log(`Mock: Opcije za ${ticker}:`, options);
-    
-    return options;
-  } catch (error) {
-    console.error(`❌ Mock: Greška pri dohvatanju opcija:`, error);
-    throw error;
-  }
+  const nowSec = Math.floor(Date.now() / 1000);
+
+  const sets = await Promise.all(
+    dateList.map(async (d) => {
+      const settlementISO = unixToISODate(d.settlement_date);
+      const { data: chain } = await api.get(`/stocks/${stockId}/options`, {
+        params: { settlement: settlementISO },
+      });
+      const rows = chain?.rows || [];
+      const options = rows.map((r) => ({
+        strike: (r.strike ?? 0) / CENTS,
+        callLast: (r.call?.last ?? 0) / CENTS,
+        callTheta: (r.call?.theta ?? 0) / CENTS,
+        callBid: (r.call?.bid ?? 0) / CENTS,
+        callAsk: (r.call?.ask ?? 0) / CENTS,
+        callVol: r.call?.volume ?? 0,
+        callOI: r.call?.open_interest ?? 0,
+        putLast: (r.put?.last ?? 0) / CENTS,
+        putTheta: (r.put?.theta ?? 0) / CENTS,
+        putBid: (r.put?.bid ?? 0) / CENTS,
+        putAsk: (r.put?.ask ?? 0) / CENTS,
+        putVol: r.put?.volume ?? 0,
+        putOI: r.put?.open_interest ?? 0,
+      }));
+      return {
+        settlementDate: settlementISO,
+        daysToExpiry: d.days_to_expiry ?? daysBetween(nowSec, d.settlement_date),
+        options,
+      };
+    }),
+  );
+
+  return sets.filter((s) => s.options.length > 0);
 }


### PR DESCRIPTION
## Summary
- Replace `SecurityDetailService` mock data with real `/api` calls: listing lookup by ticker → `/listings/:id`, history via `/listings/:id/history`, options via `/stocks/:id/options/dates` + `/stocks/:id/options`.
- Map frontend period labels (`1D/1W/1M/1Y/5Y`) to backend (`day/week/month/year/5y`); divide cents-encoded ints by 100.
- `useSecurityDetails` now keys history/options off `detail.id` / `detail.stockId`, loads options only for stocks, and adds cancellation guards.
- History rows derive `high`/`low` from `max/min(price, ask, bid)` because the backend response has no OHLC; chart and history table keep rendering unchanged.

## Test plan
- [ ] Open `/securities/:ticker` for a stock — header, chart, history table, and options chain all render with real data.
- [ ] Switch chart period (1D/1W/1M/1Y/5Y) and confirm the request fires with the mapped backend period.
- [ ] Open detail for a futures listing — options table is hidden, history/chart still render.
- [ ] Verify a 404 ticker surfaces the existing error state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)