### PR TITLE
fix(actuary): reject limit <= 0 and limit < usedLimit in UI

### DIFF
--- a/cypress/e2e/integration/agents-management.cy.js
+++ b/cypress/e2e/integration/agents-management.cy.js
@@ -62,9 +62,9 @@ describe("Upravljanje aktuarima — #1–9", () => {
     });
   });
 
-  // #4: Negativan limit odbacuje frontend (val < 0 -> alert).
-  // Main's page accepts 0; we test the actually-rejected path (negatives).
-  it("#4: negativan limit prikazuje validacionu poruku", () => {
+  // #4: Nepozitivan limit (negativan ili 0) odbacuje frontend pre slanja.
+  // Spec §S4: "limit must be > 0", a ne >= 0.
+  it("#4: nepozitivan limit prikazuje validacionu poruku", () => {
     const alerts = captureAlerts();
     cy.loginAs("supervisor");
     cy.visit(PAGE);
@@ -74,11 +74,20 @@ describe("Upravljanje aktuarima — #1–9", () => {
       cy.get(".amp-btn-save").click();
     });
     cy.wrap(alerts).should((arr) => {
-      expect(arr.join(" ")).to.match(/validnu pozitivnu/i);
+      expect(arr.join(" ")).to.match(/veći od 0/i);
     });
     cy.contains(".amp-table tbody tr", AGENT_EMAIL)
       .find(".amp-edit-input")
       .should("exist");
+
+    // Same rejection for limit = 0 (the path main allowed before this fix).
+    cy.contains(".amp-table tbody tr", AGENT_EMAIL).within(() => {
+      cy.get(".amp-edit-input").clear().type("0");
+      cy.get(".amp-btn-save").click();
+    });
+    cy.wrap(alerts).should((arr) => {
+      expect(arr.filter((m) => /veći od 0/i.test(m)).length).to.be.greaterThan(1);
+    });
   });
 
   // #5: Reset usedLimit kroz modal — modal/.amp-modal + "Potvrdi reset".

--- a/src/pages/ActuaryManagementPage.jsx
+++ b/src/pages/ActuaryManagementPage.jsx
@@ -60,8 +60,20 @@ export default function ActuaryManagementPage() {
 
     const handleLimitSave = async (id) => {
         const val = parseFloat(editValue);
-        if (isNaN(val) || val < 0) {
-            alert("Molimo unesite validnu pozitivnu vrednost.");
+        if (isNaN(val) || val <= 0) {
+            alert("Limit mora biti veći od 0.");
+            return;
+        }
+
+        // Spec §S3: novi limit ne sme biti manji od trenutno iskorišćenog —
+        // u suprotnom usedLimit > limit, agent zauvek pada na approval gate.
+        // Backend takođe odbija ovo, ali UI ne sme dozvoliti round-trip ako
+        // možemo da uporedimo lokalno.
+        const target = agents.find((a) => a.id === id);
+        if (target && val < target.usedLimit) {
+            alert(
+                `Novi limit (${formatCurrency(val)}) ne može biti manji od trenutno iskorišćenog (${formatCurrency(target.usedLimit)}). Resetujte iskorišćeni limit pre izmene.`
+            );
             return;
         }
 


### PR DESCRIPTION
## Summary
- Limit form accepted \`0\` even though the alert promised "validnu pozitivnu vrednost". Now requires \`> 0\` with a matching message.
- Limit form sent values lower than the agent's current \`usedLimit\` to the backend, which silently persisted them and left \`usedLimit > limit\` — that breaks the over-limit approval routing in trading. Now rejected client-side, with both numbers shown so the supervisor knows to reset \`usedLimit\` first.

Spec mapping: TestoviCelina3 scenarios 3 and 4. Pairs with backend PR \`fix/agent-limit-validation\` on Banka-3-Backend (#261).

## Test plan
- [ ] Cypress \`agents-management.cy.js\` #4 (rewritten): asserts both negative and zero are rejected with the new "veći od 0" copy
- [ ] Manual: log in as supervisor, open Upravljanje aktuarima, try setting an agent's limit to 0 (rejected), then bring \`usedLimit\` above 0 via fills and try setting a limit below it (rejected with the new message)