### PR TITLE
fix(orders): surface contract_size + settlement_date from listing detail

### DIFF
--- a/src/pages/CreateOrderPage.jsx
+++ b/src/pages/CreateOrderPage.jsx
@@ -128,14 +128,14 @@ export default function CreateOrderPage() {
     return security?.price || 0;
   }, [orderType, limitPrice, stopPrice, security]);
 
-  // The detail endpoint doesn't surface contract_size yet; default to 1 for
-  // stocks/forex and rely on the backend's authoritative computation. This
-  // matches the cy createOrderApi tests that pass `quantity` directly.
-  const contractSize = 1;
+  // contractSize comes from the listing detail (1 for stocks/forex, lot size
+  // for futures). Without it, the "approximate total" estimate displayed below
+  // is off by a factor of contract_size on futures orders.
+  const contractSize = security?.contractSize && security.contractSize > 0 ? security.contractSize : 1;
 
   const approxTotalMajor = useMemo(() => {
     return Math.max(0, pricePerUnit * Number(quantity || 0) * contractSize);
-  }, [pricePerUnit, quantity]);
+  }, [pricePerUnit, quantity, contractSize]);
 
   const commissionMajor = commissionFor(orderType, approxTotalMajor, isEmployee);
   const grandTotalMajor = approxTotalMajor + commissionMajor;
@@ -500,6 +500,12 @@ export default function CreateOrderPage() {
               <div><dt>Smer</dt><dd>{directionLabel}</dd></div>
               <div><dt>Tip</dt><dd>{orderTypeLabel}</dd></div>
               <div><dt>Količina</dt><dd>{Number(quantity)}</dd></div>
+              {contractSize > 1 && (
+                <>
+                  <div><dt>Veličina ugovora</dt><dd>{contractSize}</dd></div>
+                  <div><dt>Broj jedinica</dt><dd>{Number(quantity) * contractSize}</dd></div>
+                </>
+              )}
               {showLimitField && (
                 <div><dt>Limit</dt><dd>{formatCurrency(Number(limitPrice) || 0, securityCurrency)}</dd></div>
               )}

--- a/src/services/SecurityDetailService.js
+++ b/src/services/SecurityDetailService.js
@@ -43,6 +43,11 @@ function mapListingToDetail(l) {
     change: (l.change ?? 0) / CENTS,
     volume: l.volume ?? 0,
     exchange: l.exchange_acronym || "",
+    // contract_size is 1 for stocks and the future's lot size for futures.
+    // CreateOrderPage needs it so the "approximate total" estimate matches
+    // backend pricing, which is contract_size × price × quantity.
+    contractSize: l.contract_size && l.contract_size > 0 ? l.contract_size : 1,
+    settlementDate: l.settlement_date_unix || null,
   };
 }
 


### PR DESCRIPTION
## Summary
\`mapListingToDetail\` in \`SecurityDetailService.js\` dropped two fields the backend already returns on \`/listings/:id\`, and the order form had hard-coded fallbacks that masked the resulting bugs:

- **contract_size** — \`CreateOrderPage.jsx\` had \`const contractSize = 1\`, so the "Aproks. ukupno" estimate for futures (lot size > 1) was wrong by a factor of contract size. Now the mapper exposes \`l.contract_size\`, the estimate uses it, and the confirm dialog adds \`Veličina ugovora\` and \`Broj jedinica\` rows when \`contract_size > 1\`.
- **settlement_date** — both \`CreateOrderPage\` and \`SecurityDetailPage\` reference \`security.settlementDate\` to detect expired contracts, but the mapper never set it. \`isPastSettlement()\` was always returning false, so the form let users submit orders against expired futures (backend rejected them, but the UX was wrong).

Spec mapping: TestoviCelina3 §S32 (expired-contract rejection) and §S33 (confirm dialog shows the obvious order details).

## Test plan
- [ ] Manual: open the order form for a future with contract_size > 1; confirm the estimate matches contract_size × price × quantity, and the confirm dialog shows \`Veličina ugovora\` + \`Broj jedinica\`.
- [ ] Manual: open the form for a future with a settlement date in the past; confirm the warning banner appears and submit is disabled.
- [ ] Stocks (contract_size = 1) should look unchanged — extra dialog rows are gated behind \`contractSize > 1\`.

> No local Node toolchain in this environment — Cypress runs in CI.