### PR TITLE
fix(orders): warn before submitting orders on a closed exchange

### DIFF
--- a/src/pages/BerzaPage.jsx
+++ b/src/pages/BerzaPage.jsx
@@ -2,66 +2,8 @@ import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { getExchanges, setExchangeOpenOverride } from "../services/ExchangeService";
 import Sidebar from "../components/Sidebar.jsx";
+import { computeExchangeStatus } from "../utils/exchangeHours.js";
 import "./BerzaPage.css";
-
-// Spec p.40 says all exchanges in the same polity share working hours, so a
-// per-row local-time check is sufficient to compute "open"/"closed" without
-// hitting holiday calendars. The backend may also surface an is_open flag —
-// we prefer that when available so we don't drift from server state.
-function parseTimeOfDay(value) {
-  if (!value || typeof value !== "string") return null;
-  const [h, m = "0"] = value.split(":");
-  const hh = Number(h);
-  const mm = Number(m);
-  if (Number.isNaN(hh) || Number.isNaN(mm)) return null;
-  return hh * 60 + mm;
-}
-
-function parseUtcOffset(value) {
-  if (value == null) return 0;
-  if (typeof value === "number") return value;
-  const s = String(value).trim();
-  // Accepts forms like "+8", "-3", "+8:00", "+05:30".
-  const match = s.match(/^([+-]?)(\d{1,2})(?::?(\d{2}))?$/);
-  if (!match) return 0;
-  const sign = match[1] === "-" ? -1 : 1;
-  const h = Number(match[2]);
-  const m = Number(match[3] || 0);
-  return sign * (h + m / 60);
-}
-
-function computeStatus(ex) {
-  if (ex.open_override) {
-    return { open: true, label: "Otvorena (override)", className: "open" };
-  }
-  if (typeof ex.is_open === "boolean") {
-    return {
-      open: ex.is_open,
-      label: ex.is_open ? "Otvorena" : "Zatvorena",
-      className: ex.is_open ? "open" : "closed",
-    };
-  }
-  const openMin = parseTimeOfDay(ex.open_time);
-  const closeMin = parseTimeOfDay(ex.close_time);
-  if (openMin == null || closeMin == null) {
-    return { open: false, label: "Nepoznato", className: "unknown" };
-  }
-  const offsetH = parseUtcOffset(ex.time_zone_offset);
-  const now = new Date();
-  const localMs = now.getTime() + (now.getTimezoneOffset() + offsetH * 60) * 60000;
-  const localDate = new Date(localMs);
-  const day = localDate.getUTCDay(); // we already shifted to "exchange local"
-  if (day === 0 || day === 6) {
-    return { open: false, label: "Zatvorena (vikend)", className: "closed" };
-  }
-  const minutesNow = localDate.getUTCHours() * 60 + localDate.getUTCMinutes();
-  const isOpen = minutesNow >= openMin && minutesNow <= closeMin;
-  return {
-    open: isOpen,
-    label: isOpen ? "Otvorena" : "Zatvorena",
-    className: isOpen ? "open" : "closed",
-  };
-}
 
 export default function BerzaPage() {
   const navigate = useNavigate();
@@ -103,7 +45,7 @@ export default function BerzaPage() {
 
   const rows = useMemo(() => exchanges.map((ex) => ({
     ...ex,
-    status: computeStatus(ex),
+    status: computeExchangeStatus(ex),
   })), [exchanges]);
 
   const handleToggleOverride = async (exchange) => {

--- a/src/pages/CreateOrderPage.jsx
+++ b/src/pages/CreateOrderPage.jsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import Sidebar from "../components/Sidebar.jsx";
 import { getAccounts } from "../services/AccountService.js";
 import { getSecurityDetail } from "../services/SecurityDetailService.js";
+import { getExchanges } from "../services/ExchangeService.js";
 import {
   createOrder,
   toMinor,
@@ -10,6 +11,7 @@ import {
   ORDER_DIRECTION_LABEL,
 } from "../services/OrderService.js";
 import { formatCurrency } from "../utils/loanCalculations.js";
+import { computeExchangeStatus, findExchangeByAcronym } from "../utils/exchangeHours.js";
 import "./CreateOrderPage.css";
 
 const ORDER_TYPES = [
@@ -63,6 +65,7 @@ export default function CreateOrderPage() {
 
   const [security, setSecurity] = useState(null);
   const [accounts, setAccounts] = useState([]);
+  const [exchanges, setExchanges] = useState([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState("");
 
@@ -83,16 +86,19 @@ export default function CreateOrderPage() {
     let cancelled = false;
     (async () => {
       try {
-        // Resolve security (by ticker or listing id) and the user's accounts
-        // in parallel — both are needed before the form is interactive.
+        // Resolve security, the user's accounts, and the exchange list in
+        // parallel — all three are needed before the form is interactive
+        // (exchanges drive the closed-market warning, see §S45).
         const securityKey = tickerParam || listingIdParam;
-        const [sec, accs] = await Promise.all([
+        const [sec, accs, exs] = await Promise.all([
           securityKey ? getSecurityDetail(securityKey).catch(() => null) : Promise.resolve(null),
           getAccounts().catch(() => []),
+          getExchanges().catch(() => []),
         ]);
         if (cancelled) return;
         setSecurity(sec);
         setAccounts(Array.isArray(accs) ? accs : []);
+        setExchanges(Array.isArray(exs) ? exs : []);
         if (Array.isArray(accs) && accs.length > 0) {
           // Preselect first account that matches the security currency where
           // possible — keeps the displayed "Procena troškova" in a single
@@ -142,6 +148,18 @@ export default function CreateOrderPage() {
 
   const settlementExpired = isPastSettlement(security?.settlementDate);
 
+  // Spec §S45: warn before submit when the exchange is closed. Forex has no
+  // exchange and is always tradable; same for securities whose exchange we
+  // can't resolve (we don't want to false-positive a warning on missing data).
+  // Market orders are the harder case — the backend rejects them when the
+  // market is closed (see §S46), so we surface that as a hard block here too.
+  const exchangeStatus = useMemo(() => {
+    if (!security || security.type === "forex" || !security.exchange) return null;
+    const ex = findExchangeByAcronym(exchanges, security.exchange);
+    return ex ? computeExchangeStatus(ex) : null;
+  }, [security, exchanges]);
+  const exchangeClosed = exchangeStatus != null && !exchangeStatus.open;
+
   function validate() {
     const errs = {};
     const q = Number(quantity);
@@ -164,6 +182,13 @@ export default function CreateOrderPage() {
     }
     if (margin && !canMargin) {
       errs.margin = "Nemate dozvolu za margin trgovanje.";
+    }
+    // Block market orders pre-flight when the exchange is closed; the backend
+    // rejects them too (server.go: "exchange is closed; market orders cannot
+    // be placed"), so failing fast here saves a round-trip and tells the user
+    // why. Limit/stop variants are still allowed — they wait for a trigger.
+    if (orderType === "market" && exchangeClosed) {
+      errs.exchange = "Berza je zatvorena — Market nalozi se ne mogu kreirati. Koristite Limit/Stop ili sačekajte otvaranje.";
     }
     return errs;
   }
@@ -269,6 +294,14 @@ export default function CreateOrderPage() {
             Kreiranje naloga je onemogućeno.
           </div>
         )}
+        {exchangeClosed && (
+          <div className="co-banner co-banner--warning">
+            Berza {security?.exchange || ""} je trenutno zatvorena
+            ({exchangeStatus?.label || "zatvorena"}). Market nalozi će biti odbijeni;
+            Limit/Stop nalozi se mogu kreirati i čekaće okidač.
+          </div>
+        )}
+        {errors.exchange && <div className="co-banner co-banner--error">{errors.exchange}</div>}
         {isEmployee && (
           <div className="co-banner co-banner--info">
             Trguje se sa bankinog trading računa. Provizija za zaposlene je 0.

--- a/src/utils/exchangeHours.js
+++ b/src/utils/exchangeHours.js
@@ -1,0 +1,79 @@
+// Shared open/closed computation for exchanges.
+//
+// The backend stores per-exchange working hours plus an `open_override` flag
+// (the supervisor toggle on /berze used for testing outside trading hours,
+// see e2e.txt:19). The same computation needs to run in two places — the
+// Berza listing page and the order form's pre-flight warning — so it lives
+// here to avoid drift.
+//
+// We prefer the backend's `is_open` flag when present; fall back to the
+// stored open/close clock + offset, weekend skip, and override.
+
+function parseTimeOfDay(value) {
+  if (!value || typeof value !== "string") return null;
+  const [h, m = "0"] = value.split(":");
+  const hh = Number(h);
+  const mm = Number(m);
+  if (Number.isNaN(hh) || Number.isNaN(mm)) return null;
+  return hh * 60 + mm;
+}
+
+function parseUtcOffset(value) {
+  if (value == null) return 0;
+  if (typeof value === "number") return value;
+  const s = String(value).trim();
+  // Accepts "+8", "-3", "+8:00", "+05:30".
+  const match = s.match(/^([+-]?)(\d{1,2})(?::?(\d{2}))?$/);
+  if (!match) return 0;
+  const sign = match[1] === "-" ? -1 : 1;
+  const h = Number(match[2]);
+  const m = Number(match[3] || 0);
+  return sign * (h + m / 60);
+}
+
+export function computeExchangeStatus(ex) {
+  if (!ex) {
+    return { open: false, label: "Nepoznato", className: "unknown", override: false };
+  }
+  if (ex.open_override) {
+    return { open: true, label: "Otvorena (override)", className: "open", override: true };
+  }
+  if (typeof ex.is_open === "boolean") {
+    return {
+      open: ex.is_open,
+      label: ex.is_open ? "Otvorena" : "Zatvorena",
+      className: ex.is_open ? "open" : "closed",
+      override: false,
+    };
+  }
+  const openMin = parseTimeOfDay(ex.open_time);
+  const closeMin = parseTimeOfDay(ex.close_time);
+  if (openMin == null || closeMin == null) {
+    return { open: false, label: "Nepoznato", className: "unknown", override: false };
+  }
+  const offsetH = parseUtcOffset(ex.time_zone_offset);
+  const now = new Date();
+  const localMs = now.getTime() + (now.getTimezoneOffset() + offsetH * 60) * 60000;
+  const localDate = new Date(localMs);
+  const day = localDate.getUTCDay();
+  if (day === 0 || day === 6) {
+    return { open: false, label: "Zatvorena (vikend)", className: "closed", override: false };
+  }
+  const minutesNow = localDate.getUTCHours() * 60 + localDate.getUTCMinutes();
+  const isOpen = minutesNow >= openMin && minutesNow <= closeMin;
+  return {
+    open: isOpen,
+    label: isOpen ? "Otvorena" : "Zatvorena",
+    className: isOpen ? "open" : "closed",
+    override: false,
+  };
+}
+
+// findExchangeByAcronym returns the exchange whose acronym matches the
+// supplied value (case-insensitive). Useful for resolving a security's
+// `exchange` string back to the exchange row that carries hours/override.
+export function findExchangeByAcronym(exchanges, acronym) {
+  if (!acronym || !Array.isArray(exchanges)) return null;
+  const target = String(acronym).toUpperCase();
+  return exchanges.find((ex) => (ex.acronym || "").toUpperCase() === target) || null;
+}


### PR DESCRIPTION
## Summary
\`CreateOrderPage\` had no closed-market awareness. The backend rejects market orders against a closed exchange ("exchange is closed; market orders cannot be placed" — \`server.go:142\`), but the user only saw it as a generic submit error after the round-trip.

Changes:
- Form now fetches the exchanges list alongside the security/accounts and resolves the matching exchange by acronym.
- A warning banner appears when the exchange is closed (or open via supervisor override, weekend, outside working hours), explaining that Limit/Stop orders are still fine but Market orders will be rejected.
- Pre-flight validation blocks Market submissions client-side with an inline error, so the user gets a fast clear message instead of a backend round-trip.
- The open/closed computation that was duplicated between \`BerzaPage\` and this form moves to \`src/utils/exchangeHours.js\`. \`BerzaPage\` now imports from there too — both pages stay in sync.

Spec mapping: TestoviCelina3 §S45 (closed-exchange warning) and §S46 (market-order rejection during closure). After-hours simulation intentionally out of scope (\`hours.go:134\`).

For testing: flip "Test mod" on \`/berze\` to set \`open_override\` per the e2e spec note (\`e2e.txt:19\`).

## Test plan
- [ ] Manual, exchange closed (e.g. NYSE outside trading hours): open the order form for an MSFT listing → warning banner visible, Market submit blocked, Limit/Stop submit allowed.
- [ ] Manual, exchange overridden open: enable Test mod on /berze, return to the order form → no warning, all order types submit through.
- [ ] Manual, weekend: warning labelled "Zatvorena (vikend)".
- [ ] Cypress: existing trading-day-e2e relies on \`open_override\` being on; behavior unchanged.

> No local Node toolchain in this environment — Cypress runs in CI.