### PR TITLE
test(cypress): activate the 3 cron-driven skips

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,5 +1,5 @@
 import { defineConfig } from "cypress";
-import { dbReset } from "./cypress/plugins/db-reset.js";
+import { dbReset, dbExec } from "./cypress/plugins/db-reset.js";
 
 const SCHEMA_PATH =
   process.env.CYPRESS_SCHEMA_SQL || "/backend-sql/schema.sql";
@@ -31,6 +31,7 @@ export default defineConfig({
             vars: { admin_email: ADMIN_EMAIL, client_email: CLIENT_EMAIL },
             restartContainers: RESTART_CONTAINERS,
           }),
+        "db:exec": ({ sql, params }) => dbExec({ sql, params }),
       });
     },
     viewportWidth: 1280,

--- a/cypress/e2e/celina3/agents-management.cy.js
+++ b/cypress/e2e/celina3/agents-management.cy.js
@@ -135,8 +135,38 @@ describe("Upravljanje aktuarima — #1–9", () => {
     });
   });
 
-  // #7: SKIPPED — see trading-day-e2e DEO 12 rationale.
-  it.skip("#7: automatski reset u 23:59h — bez admin trigger endpoint-a", () => {});
+  // #7: Automatski reset u 23:59h. The real cron lives at
+  // services/bank/internal/bank/cron.go (`RunDailyUsedLimitReset`); cypress
+  // can't wait until 23:59 wall-clock, so we drive it through the bank's
+  // debug HTTP listener (cron_debug.go, env-gated by BANK_DEBUG_HTTP_PORT).
+  // Pre-state: bump the agent's used_limit so the post-trigger 0 isn't
+  // trivially the same value.
+  it("#7: automatski reset u 23:59h zeruje used_limit svim aktuarima", () => {
+    const debugBase =
+      Cypress.env("BANK_DEBUG_URL") || "http://localhost:50090";
+
+    cy.task("db:exec", {
+      sql: "UPDATE employees SET used_limit = 50000 WHERE email = $1",
+      params: [AGENT_EMAIL],
+    }).then((res) => {
+      expect(res.rowCount, "agent row updated").to.be.greaterThan(0);
+    });
+
+    cy.request({
+      method: "POST",
+      url: `${debugBase}/debug/cron/used-limit-reset`,
+    })
+      .its("status")
+      .should("eq", 204);
+
+    cy.task("db:exec", {
+      sql: "SELECT used_limit FROM employees WHERE email = $1",
+      params: [AGENT_EMAIL],
+    }).then((res) => {
+      // pg returns BIGINT as a string; coerce before numeric assert.
+      expect(Number(res.rows[0].used_limit), "used_limit post-cron").to.eq(0);
+    });
+  });
 
   // #8: Admin je ujedno i supervizor — admin moze portal
   it("#8: admin moze da otvori portal (admin implies supervisor)", () => {

--- a/cypress/e2e/celina3/tax-tracking.cy.js
+++ b/cypress/e2e/celina3/tax-tracking.cy.js
@@ -71,11 +71,38 @@ describe("Porez tracking — #74–81", () => {
     cy.wait("@debtsFiltered").its("request.url").should("include", "name=Marko");
   });
 
-  // #78: Automatski mesecni cron — RunTaxJob u tax/cron.go pokrece se mesecno.
-  // Nema HTTP endpoint-a za on-demand pokretanje cron-a; ručno pokretanje (#79)
-  // je jedini eksterni okidač iste logike obracuna.
-  it.skip("#78: automatski mesecni obračun (cron) — bez on-demand endpoint-a", () => {
-    // TODO: dodati POST /tax/cron/run da bi se cron mogao testirati direktno.
+  // #78: Automatski mesecni cron. RunMonthlyCapitalGainsCollection runs at
+  // 23:50 on the last calendar day; it's invoked here through the bank's
+  // debug HTTP listener (cron_debug.go). The cron entrypoint scopes to the
+  // current month; the seed's only unpaid period is 2026-04, so we use the
+  // debug endpoint's `?period=` override to target it without touching the
+  // shared seed.
+  it("#78: cron pokreće obračun i markira period=YYYY-MM kao plaćen", () => {
+    const debugBase =
+      Cypress.env("BANK_DEBUG_URL") || "http://localhost:50090";
+    const PERIOD = "2026-04";
+
+    // Pre-state: seed has at least one unpaid 2026-04 row.
+    cy.task("db:exec", {
+      sql: "SELECT COUNT(*)::int AS n FROM capital_gains WHERE period = $1 AND paid_at IS NULL",
+      params: [PERIOD],
+    }).then((res) => {
+      expect(res.rows[0].n, `unpaid rows for ${PERIOD} pre-cron`).to.be.greaterThan(0);
+    });
+
+    cy.request({
+      method: "POST",
+      url: `${debugBase}/debug/cron/capital-gains?period=${PERIOD}`,
+    })
+      .its("status")
+      .should("eq", 204);
+
+    cy.task("db:exec", {
+      sql: "SELECT COUNT(*)::int AS n FROM capital_gains WHERE period = $1 AND paid_at IS NULL",
+      params: [PERIOD],
+    }).then((res) => {
+      expect(res.rows[0].n, `unpaid rows for ${PERIOD} post-cron`).to.eq(0);
+    });
   });
 
   // #79: Rucno pokretanje obracuna preko TaxPage — POST /tax/run.

--- a/cypress/e2e/celina3/trading-day-e2e.cy.js
+++ b/cypress/e2e/celina3/trading-day-e2e.cy.js
@@ -18,8 +18,8 @@
 // volume + a randomized delay. We assert remaining_portions monotonically
 // reaches 0, not exact chunk widths.
 //
-// DEO 12 (23:59 used_limit reset) is skipped — there's no HTTP trigger for
-// RunDailyUsedLimitReset on demand.
+// DEO 12 (23:59 used_limit reset) drives the cron through bank's debug HTTP
+// listener (cron_debug.go, env-gated by BANK_DEBUG_HTTP_PORT).
 
 const NASDAQ_MIC = "XNAS";
 const TICKER = "MSFT";
@@ -393,9 +393,34 @@ describe("E2E: Kompletan radni dan na berzi", () => {
   // -------------------------------------------------------------------------
   // DEO 12 — Automatski reset usedLimit-a u 23:59h
   // -------------------------------------------------------------------------
-  // Skipped: there's no HTTP trigger for RunDailyUsedLimitReset on demand.
-  // Cron at services/bank/internal/bank/cron.go fires at 23:59 server-local.
-  it.skip("DEO 12: automatski reset usedLimit-a u 23:59h", () => {
-    // TODO: enable once a manual trigger endpoint exists.
+  // The 23:59 cron (`RunDailyUsedLimitReset` in services/bank/internal/bank/
+  // cron.go) is invoked through the bank's debug HTTP listener. We bump the
+  // agent's used_limit explicitly rather than relying on DEO 1–11 to have
+  // left it non-zero — the trade flow may end at 0 depending on chunking.
+  it("DEO 12: automatski reset usedLimit-a u 23:59h", () => {
+    const debugBase =
+      Cypress.env("BANK_DEBUG_URL") || "http://localhost:50090";
+
+    cy.task("db:exec", {
+      sql: "UPDATE employees SET used_limit = 25000 WHERE id = $1",
+      params: [ctx.agentId],
+    }).then((res) => {
+      expect(res.rowCount, "agent row updated").to.be.greaterThan(0);
+    });
+
+    cy.request({
+      method: "POST",
+      url: `${debugBase}/debug/cron/used-limit-reset`,
+    })
+      .its("status")
+      .should("eq", 204);
+
+    cy.task("db:exec", {
+      sql: "SELECT used_limit FROM employees WHERE id = $1",
+      params: [ctx.agentId],
+    }).then((res) => {
+      // pg returns BIGINT as a string; coerce before numeric assert.
+      expect(Number(res.rows[0].used_limit), "used_limit post-cron").to.eq(0);
+    });
   });
 });

--- a/cypress/plugins/db-reset.js
+++ b/cypress/plugins/db-reset.js
@@ -93,3 +93,24 @@ export async function dbReset({
 
   return null;
 }
+
+// dbExec runs a parameterized SQL statement against the same database the
+// suite resets against, returning row count. Used by cron-trigger tests
+// that need to seed specific row state (e.g. used_limit > 0) without
+// running a full domain flow first.
+export async function dbExec({ sql, params = [] }) {
+  const client = new Client({
+    host: process.env.PG_HOST || "localhost",
+    port: Number(process.env.PG_PORT || 5432),
+    user: process.env.PG_USER || "banka",
+    password: process.env.PG_PASSWORD || "banka_secret",
+    database: process.env.PG_DB || "banka",
+  });
+  await client.connect();
+  try {
+    const res = await client.query(sql, params);
+    return { rowCount: res.rowCount ?? 0, rows: res.rows ?? [] };
+  } finally {
+    await client.end();
+  }
+}


### PR DESCRIPTION
## Summary
Lifts the three previously-skipped cron-driven scenarios (agents-management #7, trading-day-e2e DEO 12, tax-tracking #78) by driving the actual cron entrypoints through the bank service's debug HTTP listener (companion Banka-3-Backend PR #263). Adds a `db:exec` cypress task on the existing pg client for pre-/post-state seeding.

- New baseline: **72 / 68 / 4 / 0** (was 72 / 65 / 7 / 0). Remaining 4 pendings are seed-depth gaps only (orders-creation #42/#46, orders-execution #60, portfolio #71).
- Depends on Banka-3-Backend PR #263 (must be merged + bank container running with `BANK_DEBUG_HTTP_PORT=50090` for these specs to pass).

## Test plan
- [x] Two-spec re-run after fixing the BIGINT-as-string assertion: `agents-management.cy.js` 8/8, `trading-day-e2e.cy.js` 12/12.
- [x] Full Celina 3 suite: 72/68/4/0, 0 fail across all 9 specs.
- [x] `db:exec` plumbing exercised by both used_limit (UPDATE + SELECT) and capital_gains (SELECT COUNT(*)) calls.