### PR TITLE
test(cypress): activate orders-creation #46 (closed-market market order)

### DIFF
--- a/cypress/e2e/celina3/orders-creation.cy.js
+++ b/cypress/e2e/celina3/orders-creation.cy.js
@@ -332,16 +332,32 @@ describe("Kreiranje naloga — #26–47", () => {
     // See cypress/e2e/ui/create-order-modal.cy.js
   });
 
-  // #46 Spec ↔ code divergence. Spec says: market order while exchange is
-  // closed is *created* and runs with a 30-min delay between fills. Backend
-  // (server.go:142) hard-rejects with FailedPrecondition. PR #201 added a
-  // frontend warning before submit but did not change the rejection behavior.
-  // Asserting the current code's rejection would give green CI for behavior
-  // that contradicts the spec — strictly worse than no test. Skipping until
-  // backend implements delayed execution.
-  it.skip("#46: market order pri zatvorenoj berzi se kreira sa odloženim izvršavanjem", () => {
-    // TODO: re-enable once server.go's closed-market path queues with delay
-    // instead of returning FailedPrecondition.
+  // #46 Spec p.57: market order pri zatvorenoj berzi se *kreira* i čeka da
+  // berza otvori, sa 30-min delay bonusom u izvršavaču. Force-closing the
+  // exchange via closed_override (added with this lift) keeps the assertion
+  // wall-clock-independent — without it, runs during NY business hours
+  // would naturally see IsOpen=true and the test would get no signal.
+  it("#46: market order pri zatvorenoj berzi se kreira sa odloženim izvršavanjem", () => {
+    cy.loginAs("supervisor");
+    cy.setExchangeClosed(NASDAQ_MIC, true);
+    cy.loginAs("agent");
+    cy.findListingByTicker(TICKER).then((l) => {
+      cy.createOrderApi({
+        account_number: BANK_USD_ACCOUNT,
+        order_type: "market",
+        direction: "buy",
+        quantity: 1,
+        listing_id: l.id,
+      }).then((r) => {
+        expect(r.status, "closed-market market order accepted, not rejected").to.be.oneOf([200, 201]);
+        cy.getOrderById(r.body.order_id).then((o) => {
+          expect(o.after_hours, "after_hours flag set when exchange is closed").to.eq(true);
+        });
+      });
+    });
+    // Restore: subsequent tests in the file rely on NASDAQ being open.
+    cy.loginAs("supervisor");
+    cy.setExchangeClosed(NASDAQ_MIC, false);
   });
 
   // #47 After-hours warning is a UI concern (modal text). Backend just sets

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -177,6 +177,32 @@ Cypress.Commands.add("setExchangeOpen", (micCode, open = true) => {
   });
 });
 
+// Inverse of setExchangeOpen — force-closes an exchange regardless of the
+// wall clock or open_override (#46). Required for closed-market tests that
+// need to run during NY business hours without time control.
+Cypress.Commands.add("setExchangeClosed", (micCode, closed = true) => {
+  return cy.window().then((win) => {
+    const token = win.sessionStorage.getItem("accessToken");
+    if (!token) throw new Error("setExchangeClosed requires prior login (loginAs)");
+    return cy
+      .request({
+        method: "GET",
+        url: "/api/exchanges",
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      .then((resp) => {
+        const ex = (resp.body || []).find((e) => e.mic_code === micCode);
+        if (!ex) throw new Error(`Exchange MIC=${micCode} not found in /exchanges`);
+        return cy.request({
+          method: "PATCH",
+          url: `/api/exchanges/${ex.id}/closed-override`,
+          headers: { Authorization: `Bearer ${token}` },
+          body: { closed_override: closed },
+        }).then(() => cy.wrap(ex));
+      });
+  });
+});
+
 // Resolve a listing by ticker (e.g. "MSFT") on a given MIC. Returns the listing object.
 Cypress.Commands.add("findListingByTicker", (ticker) => {
   return cy.window().then((win) => {

--- a/front.sh
+++ b/front.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Run each Celina3 cypress spec in isolation against a fresh DB.
+# Per-spec invocation is required: services hold in-process state
+# (executor queues, exchange-hours overrides) that survives db:reset
+# but not a container restart.
+set -u
+
+BACKEND=/home/user/si/Banka-3-Backend
+FRONTEND=/home/user/si/Banka-3-Frontend
+LOG_DIR=$FRONTEND/cypress-run
+mkdir -p "$LOG_DIR"
+SUMMARY="$LOG_DIR/SUMMARY.txt"
+: > "$SUMMARY"
+
+SPECS=(
+  agents-management.cy.js
+  exchanges.cy.js
+  margin-aon.cy.js
+  orders-approval.cy.js
+  orders-creation.cy.js
+  orders-execution.cy.js
+  portfolio.cy.js
+  tax-tracking.cy.js
+  trading-day-e2e.cy.js
+)
+
+reset_db() {
+  echo "  >> nuke/schema/seed + restart bank,gateway,exchange"
+  ( cd "$BACKEND" && \
+    make nuke   >/dev/null 2>&1 && \
+    make schema >/dev/null 2>&1 && \
+    make seed   >/dev/null 2>&1 )
+  docker restart bank gateway exchange >/dev/null 2>&1
+  for i in $(seq 1 30); do
+    code=$(curl -sS -m 2 -o /dev/null -w "%{http_code}" http://localhost:8080/api/exchanges 2>/dev/null || echo 000)
+    if [ "$code" = "401" ]; then return 0; fi
+    sleep 1
+  done
+  echo "  !! gateway didn't come back to 401 in 30s (last=$code)"
+}
+
+cd "$FRONTEND"
+
+for spec in "${SPECS[@]}"; do
+  echo "===== $spec ====="
+  reset_db
+
+  log="$LOG_DIR/${spec}.log"
+  CYPRESS_SCHEMA_SQL=$BACKEND/scripts/db/schema.sql \
+  CYPRESS_SEED_SQL=$BACKEND/scripts/db/seed.sql \
+  CYPRESS_RESTART_CONTAINERS=bank,gateway,exchange \
+  npx cypress run --spec "cypress/e2e/celina3/$spec" >"$log" 2>&1
+  rc=$?
+
+  # Cypress wraps the summary table in box-art (│), so we strip non-key chars
+  # before matching. Also trims runs of whitespace for compactness.
+  summary_line=$(grep -E "(Tests|Passing|Failing|Pending|Skipped):" "$log" | sed 's/[^A-Za-z0-9: ]//g; s/  */ /g; s/^ //' | tr '\n' ' ')
+  echo "$spec  rc=$rc  $summary_line" | tee -a "$SUMMARY"
+done
+
+echo
+echo "===== ALL DONE ====="
+cat "$SUMMARY"


### PR DESCRIPTION
## Summary
- Lifts cypress orders-creation skip #46 (spec p.57: market order placed while exchange is closed should be queued with delayed execution, not rejected). Pairs with Banka-3-Backend #265.
- New \`cy.setExchangeClosed\` helper backed by the new \`PATCH /exchanges/:id/closed-override\` endpoint. Required because \`cy.setExchangeOpen(false)\` only clears \`open_override\` and falls back to the wall clock — runs during NY business hours would otherwise leave NASDAQ naturally open and the test would get no signal.
- The lifted test force-closes NASDAQ, posts a market BUY, asserts 200/201 + \`after_hours=true\` on the persisted order, and restores the override before subsequent tests.
- Adds \`front.sh\` (the per-spec runner). Pairs \`cy.task('db:reset')\` with a full \`make nuke\` + container restart between specs because services hold in-process state (executor queues, exchange-hours overrides) that a Postgres truncate doesn't clear. The previous single-invocation runner caused cross-spec state pollution.

## Test plan
- [x] Full Celina3 cypress suite via \`bash front.sh\`: 72/70/2/0 (only #60 + #71 remain pending) against this branch + Banka-3-Backend #265.
- [x] Re-ran orders-creation in isolation: 19/19 (including the lifted #46).