### PR TITLE
test(cypress): activate portfolio #71 (actuary exercises ITM put)

### DIFF
--- a/cypress/e2e/celina3/portfolio.cy.js
+++ b/cypress/e2e/celina3/portfolio.cy.js
@@ -84,10 +84,46 @@ describe("Moj portfolio — #67–73", () => {
   });
 
   // #71: aktuar moze da iskoristi ITM put opciju.
-  // Hard to make deterministic — needs an existing put option holding, ITM.
-  // Skipped for stability; assertion logic is documented in PortfolioPage.jsx:117-132.
-  it.skip("#71: aktuar moze da iskoristi ITM put opciju", () => {
-    // TODO: requires a seeded option holding; out of scope for current seed.
+  // Seed (seed.sql, "Cypress portfolio #71" block) gives the agent a holding
+  // on MSFT_CY71_PUT_ITM (strike 63000, spot 42000, premium 1000, qty 5).
+  // Backend payout for a put = (strike − spot − premium) × qty in instrument
+  // currency; same-currency credit since the target is a USD account too:
+  //   (63000 − 42000 − 1000) × 5 = 100000 minor units USD.
+  // Payout target is marko's USD account, NOT BANK_USD_ACCOUNT — exercise
+  // debits the bank-stub system USD account (333000100000000420) for the
+  // payout, so crediting the same account would net zero.
+  it("#71: aktuar moze da iskoristi ITM put opciju", () => {
+    const PUT_TICKER = "MSFT_CY71_PUT_ITM";
+    const PAYOUT_ACCOUNT = "333000198765432120"; // marko's USD account
+    const EXPECTED_PAYOUT_USD = 100_000;
+
+    cy.loginAs("agent");
+
+    cy.task("db:exec", {
+      sql: "SELECT balance FROM accounts WHERE number = $1",
+      params: [PAYOUT_ACCOUNT],
+    }).then((res) => {
+      const balanceBefore = Number(res.rows[0].balance);
+
+      cy.visit("/portfolio");
+      cy.contains(".pf-table tr", PUT_TICKER, { timeout: 10_000 }).within(() => {
+        cy.get(".pf-exercise-btn").click();
+      });
+      cy.get(".pf-modal select").select(PAYOUT_ACCOUNT);
+      cy.get(".pf-modal").contains("button", "Iskoristi").click();
+
+      cy.contains(".pf-banner--ok", /uspe[sš]no iskori[sš][cć]ena/i, { timeout: 10_000 })
+        .should("exist");
+      cy.contains(".pf-table tr", PUT_TICKER).should("not.exist");
+
+      cy.task("db:exec", {
+        sql: "SELECT balance FROM accounts WHERE number = $1",
+        params: [PAYOUT_ACCOUNT],
+      }).then((after) => {
+        const delta = Number(after.rows[0].balance) - balanceBefore;
+        expect(delta, "USD account credited at strike not market").to.eq(EXPECTED_PAYOUT_USD);
+      });
+    });
   });
 
   // #72: klijent ne vidi opciju iskoriscavanja

--- a/src/pages/PortfolioPage.jsx
+++ b/src/pages/PortfolioPage.jsx
@@ -45,15 +45,6 @@ function fmtTimestamp(unix) {
   }
 }
 
-function isInTheMoney(option, sharedPrice) {
-  if (!option || !sharedPrice) return false;
-  const strike = Number(option.strike_price ?? option.strike) || 0;
-  const type = (option.option_type ?? option.type ?? "").toLowerCase();
-  if (type === "call") return sharedPrice > strike;
-  if (type === "put") return sharedPrice < strike;
-  return false;
-}
-
 export default function PortfolioPage() {
   const navigate = useNavigate();
   const [holdings, setHoldings] = useState([]);
@@ -254,9 +245,6 @@ export default function PortfolioPage() {
                 const profitPct = avgMajor > 0 && Number(h.amount) > 0
                   ? (profit / 100) / (avgMajor * Number(h.amount)) * 100
                   : 0;
-                const optionItm = h.asset_type === "option"
-                  ? isInTheMoney(h, (Number(h.current_price) || 0) / 100)
-                  : false;
                 const exerciseExpired = h.asset_type === "option"
                   && h.settlement_date
                   && (h.settlement_date * 1000 < Date.now());
@@ -313,14 +301,13 @@ export default function PortfolioPage() {
                         </button>
                         {canShowExercise && (
                           <button
-                            className={`sell-btn pf-exercise-btn ${optionItm ? "" : "pf-btn--muted"}`}
+                            className="sell-btn pf-exercise-btn"
                             onClick={() =>
                               setExerciseModal({
                                 holding: h,
                                 account: h.account_number || "",
                               })
                             }
-                            title={optionItm ? "Iskoristi opciju (in-the-money)" : "Opcija nije in-the-money"}
                           >
                             Iskoristi opciju
                           </button>


### PR DESCRIPTION
## Summary
- Un-skips the last `it.skip` in the Celina 3 cypress suite (`portfolio.cy.js #71`, TestoviCelina3 scenario 71). Companion to Banka-3-Backend #266 which seeds the `MSFT_CY71_PUT_ITM` option and the agent's holding.
- The test logs in as the agent, snapshots the payout account's balance, clicks "Iskoristi opciju" on the seeded row, picks marko's USD account in the modal, and asserts: success banner appears, holding row disappears, USD balance delta == `(strike − spot − premium) × qty` = 100000 minor units.
- Strips a misleading cosmetic from `PortfolioPage.jsx`: `isInTheMoney` always returned wrong results for option holdings (proto doesn't carry `strike_price`, and `current_price` for options is the premium not the underlying spot), so the "muted" styling was lying in both directions. Button stays gated on employee + non-expired option, which is what actually matters.

## Why
Closes the last skip. **Suite baseline post-merge: 72 / 72 / 0 / 0** (was 72/71/1/0).

Spec scenario 21's green/red ITM coloring lives on the stock-detail options table (different code path) and is unaffected by this strip — confirmed no `#21`/`ITM`/`strike` references anywhere in `cypress/e2e/celina3/` outside #71.

## GOTCHA
The payout target deliberately is **not** `BANK_USD_ACCOUNT` (333000100000000420). `ExerciseOption` calls `debitSystemAccount(USD)` which resolves to the `system@banka3.rs`-owned USD account — which is BANK_USD_ACCOUNT. Crediting the same account means delta = 0. First test attempt failed with "expected 0 to equal 100000" until the test was switched to marko's USD account `333000198765432120`. The frontend modal pre-fills with the holding's booking account, so the test must explicitly `.select(PAYOUT_ACCOUNT)`.

## Test plan
- [x] `npx cypress run --spec 'cypress/e2e/celina3/portfolio.cy.js'` — 7/7 passing on first attempt (no retries).
- [x] Full Celina 3 suite via `front.sh` — 72/72/0/0, no regressions.
- [x] Visual sanity: "Iskoristi opciju" button still appears for the actuary's option holdings on `/portfolio` and is no longer muted/captioned with the broken ITM tooltip.