### PR TITLE
Add option contracts overview page

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -90,6 +90,7 @@ export default function MenuDropdown() {
                     items: [
                         { label: "Hartije od vrednosti", path: "/securities" },
                         { label: "Moj portfolio", path: "/portfolio" },
+                        { label: "Opcioni ugovori", path: "/option-contracts" },
                         { label: "Moji nalozi", path: "/orders/my" },
                     ],
                 }
@@ -128,6 +129,7 @@ export default function MenuDropdown() {
             const tradingItems = [
                 { label: "Hartije od vrednosti", path: "/securities" },
                 { label: "Moj portfolio", path: "/portfolio" },
+                { label: "Opcioni ugovori", path: "/option-contracts" },
                 { label: "Moji nalozi", path: "/orders/my" },
             ];
             sections.push({

--- a/src/pages/OptionContractsPage.css
+++ b/src/pages/OptionContractsPage.css
@@ -1,0 +1,266 @@
+.option-contracts-page {
+    min-height: 100vh;
+    padding: 40px 48px;
+    color: #f1f5f9;
+    font-family: 'Inter', sans-serif;
+}
+
+.oc-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 24px;
+    margin-bottom: 24px;
+}
+
+.oc-title {
+    margin: 0;
+    font-size: 28px;
+    font-weight: 800;
+    letter-spacing: -0.03em;
+}
+
+.oc-subtitle {
+    margin: 8px 0 0;
+    color: #94a3b8;
+    font-size: 14px;
+}
+
+.oc-refresh-btn {
+    padding: 10px 18px;
+    border: 1px solid rgba(148, 163, 184, 0.28);
+    border-radius: 12px;
+    background: rgba(15, 23, 42, 0.84);
+    color: #e2e8f0;
+    font-weight: 700;
+    cursor: pointer;
+    transition: all 0.18s ease;
+}
+
+.oc-refresh-btn:hover {
+    transform: translateY(-1px);
+    border-color: rgba(96, 165, 250, 0.55);
+    color: #bfdbfe;
+}
+
+.oc-summary {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(180px, 1fr));
+    gap: 16px;
+    margin-bottom: 22px;
+}
+
+.oc-summary-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 18px 22px;
+    border-radius: 16px;
+    background: rgba(15, 23, 42, 0.84);
+    border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.oc-summary-card span {
+    color: #94a3b8;
+    font-size: 12px;
+    font-weight: 800;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+.oc-summary-card strong {
+    font-size: 26px;
+}
+
+.oc-summary-card--valid strong {
+    color: #34d399;
+}
+
+.oc-summary-card--expired strong {
+    color: #f87171;
+}
+
+.oc-toolbar {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: center;
+    margin-bottom: 18px;
+    flex-wrap: wrap;
+}
+
+.oc-tabs {
+    display: inline-flex;
+    gap: 8px;
+    padding: 6px;
+    border-radius: 14px;
+    background: rgba(15, 23, 42, 0.84);
+    border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.oc-tab {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 9px 14px;
+    border: none;
+    border-radius: 10px;
+    background: transparent;
+    color: #94a3b8;
+    cursor: pointer;
+    font-weight: 800;
+}
+
+.oc-tab span {
+    min-width: 22px;
+    padding: 2px 7px;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.14);
+    color: #cbd5e1;
+    font-size: 12px;
+}
+
+.oc-tab--active {
+    background: rgba(59, 130, 246, 0.16);
+    color: #dbeafe;
+}
+
+.oc-search {
+    min-width: 280px;
+    flex: 1;
+    max-width: 420px;
+    padding: 12px 14px;
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    background: rgba(15, 23, 42, 0.84);
+    color: #e2e8f0;
+    outline: none;
+}
+
+.oc-search:focus {
+    border-color: rgba(96, 165, 250, 0.7);
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}
+
+.oc-state {
+    padding: 22px;
+    border-radius: 16px;
+    background: rgba(15, 23, 42, 0.84);
+    border: 1px solid rgba(148, 163, 184, 0.12);
+    color: #cbd5e1;
+}
+
+.oc-state--error {
+    color: #fecaca;
+    border-color: rgba(248, 113, 113, 0.34);
+    background: rgba(127, 29, 29, 0.20);
+}
+
+.oc-table-wrapper {
+    overflow-x: auto;
+    border-radius: 16px;
+    border: 1px solid rgba(148, 163, 184, 0.12);
+    background: #111827;
+}
+
+.oc-table {
+    width: 100%;
+    min-width: 1180px;
+    border-collapse: collapse;
+}
+
+.oc-table thead {
+    background: rgba(255, 255, 255, 0.04);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.oc-table th {
+    padding: 14px 16px;
+    text-align: left;
+    font-size: 11px;
+    font-weight: 800;
+    color: #64748b;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    white-space: nowrap;
+}
+
+.oc-table td {
+    padding: 15px 16px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+    font-size: 14px;
+    color: #e2e8f0;
+    white-space: nowrap;
+}
+
+.oc-table tbody tr:hover {
+    background: rgba(255, 255, 255, 0.025);
+}
+
+.oc-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.oc-status {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 800;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.oc-status--valid {
+    background: rgba(16, 185, 129, 0.12);
+    color: #6ee7b7;
+}
+
+.oc-status--expired {
+    background: rgba(248, 113, 113, 0.12);
+    color: #fca5a5;
+}
+
+.oc-ticker {
+    color: #60a5fa;
+    font-family: 'Courier New', monospace;
+    font-weight: 800;
+}
+
+.oc-profit {
+    font-weight: 800;
+}
+
+.oc-profit--plus {
+    color: #34d399 !important;
+}
+
+.oc-profit--minus {
+    color: #f87171 !important;
+}
+
+.oc-empty {
+    text-align: center;
+    color: #94a3b8 !important;
+    padding: 34px 16px !important;
+}
+
+@media (max-width: 900px) {
+    .option-contracts-page {
+        padding: 28px 20px;
+    }
+
+    .oc-header {
+        flex-direction: column;
+    }
+
+    .oc-summary {
+        grid-template-columns: 1fr;
+    }
+
+    .oc-search {
+        max-width: none;
+        width: 100%;
+    }
+}

--- a/src/pages/OptionContractsPage.jsx
+++ b/src/pages/OptionContractsPage.jsx
@@ -1,0 +1,232 @@
+import { useEffect, useMemo, useState } from "react";
+import Sidebar from "../components/Sidebar.jsx";
+import { listSignedOptionContracts } from "../services/OptionContractsService.js";
+import { formatCurrency } from "../utils/loanCalculations.js";
+import "./OptionContractsPage.css";
+
+const FILTERS = [
+    { key: "all", label: "Svi" },
+    { key: "valid", label: "Važeći" },
+    { key: "expired", label: "Istekli" },
+];
+
+function formatDate(unix) {
+    if (!unix) return "—";
+    return new Date(unix * 1000).toLocaleDateString("sr-RS");
+}
+
+function formatDateTime(unix) {
+    if (!unix) return "—";
+    return new Date(unix * 1000).toLocaleString("sr-RS");
+}
+
+function optionTypeLabel(value) {
+    const raw = String(value || "").toLowerCase();
+    if (raw.includes("call")) return "CALL";
+    if (raw.includes("put")) return "PUT";
+    return value && value !== "—" ? String(value).toUpperCase() : "—";
+}
+
+function statusLabel(status) {
+    return status === "expired" ? "Istekao" : "Važeći";
+}
+
+export default function OptionContractsPage() {
+    const [contracts, setContracts] = useState([]);
+    const [filter, setFilter] = useState("all");
+    const [search, setSearch] = useState("");
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        let cancelled = false;
+
+        async function loadContracts() {
+            try {
+                setLoading(true);
+                const data = await listSignedOptionContracts();
+                if (!cancelled) {
+                    setContracts(Array.isArray(data) ? data : []);
+                    setError("");
+                }
+            } catch (e) {
+                if (!cancelled) {
+                    setError(e?.response?.data?.message || e.message || "Greška pri učitavanju opcionih ugovora.");
+                }
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        }
+
+        loadContracts();
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    const counts = useMemo(() => {
+        return contracts.reduce(
+            (acc, c) => {
+                acc.all += 1;
+                acc[c.status] += 1;
+                return acc;
+            },
+            { all: 0, valid: 0, expired: 0 },
+        );
+    }, [contracts]);
+
+    const visibleContracts = useMemo(() => {
+        const q = search.trim().toLowerCase();
+
+        return contracts.filter((contract) => {
+            if (filter !== "all" && contract.status !== filter) return false;
+            if (!q) return true;
+
+            return [contract.ticker, contract.name, contract.accountNumber]
+                .some((value) => String(value || "").toLowerCase().includes(q));
+        });
+    }, [contracts, filter, search]);
+
+    return (
+        <div className="option-contracts-page oc-page">
+            <Sidebar />
+
+            <div className="oc-header">
+                <div>
+                    <h1 className="oc-title">Opcioni ugovori</h1>
+                    <p className="oc-subtitle">
+                        Pregled svih potpisanih opcionih ugovora sa filterima za važeće i istekle ugovore.
+                    </p>
+                </div>
+
+                <button
+                    className="oc-refresh-btn"
+                    onClick={async () => {
+                        setLoading(true);
+                        setError("");
+                        try {
+                            const data = await listSignedOptionContracts();
+                            setContracts(Array.isArray(data) ? data : []);
+                        } catch (e) {
+                            setError(e?.response?.data?.message || e.message || "Greška pri osvežavanju opcionih ugovora.");
+                        } finally {
+                            setLoading(false);
+                        }
+                    }}
+                >
+                    Osveži
+                </button>
+            </div>
+
+            <div className="oc-summary">
+                <div className="oc-summary-card">
+                    <span>Ukupno</span>
+                    <strong>{counts.all}</strong>
+                </div>
+                <div className="oc-summary-card oc-summary-card--valid">
+                    <span>Važeći</span>
+                    <strong>{counts.valid}</strong>
+                </div>
+                <div className="oc-summary-card oc-summary-card--expired">
+                    <span>Istekli</span>
+                    <strong>{counts.expired}</strong>
+                </div>
+            </div>
+
+            <div className="oc-toolbar">
+                <div className="oc-tabs" role="tablist" aria-label="Filter opcionih ugovora">
+                    {FILTERS.map((item) => (
+                        <button
+                            key={item.key}
+                            role="tab"
+                            aria-selected={filter === item.key}
+                            className={`oc-tab${filter === item.key ? " oc-tab--active" : ""}`}
+                            onClick={() => setFilter(item.key)}
+                        >
+                            {item.label}
+                            <span>{counts[item.key]}</span>
+                        </button>
+                    ))}
+                </div>
+
+                <input
+                    className="oc-search"
+                    type="text"
+                    placeholder="Pretraži po tickeru, nazivu ili računu..."
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                />
+            </div>
+
+            {loading && <div className="oc-state">Učitavanje opcionih ugovora...</div>}
+            {!loading && error && <div className="oc-state oc-state--error">{error}</div>}
+
+            {!loading && !error && (
+                <div className="oc-table-wrapper">
+                    <table className="oc-table">
+                        <thead>
+                        <tr>
+                            <th>Status</th>
+                            <th>Ticker</th>
+                            <th>Naziv</th>
+                            <th>Tip</th>
+                            <th>Količina</th>
+                            <th>Raspoloživo</th>
+                            <th>Strike</th>
+                            <th>Avg cena</th>
+                            <th>Trenutna</th>
+                            <th>Profit</th>
+                            <th>Datum isteka</th>
+                            <th>Račun</th>
+                            <th>Modifikovano</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {visibleContracts.length === 0 && (
+                            <tr>
+                                <td colSpan={13} className="oc-empty">
+                                    Nema opcionih ugovora koji odgovaraju izabranom filteru.
+                                </td>
+                            </tr>
+                        )}
+
+                        {visibleContracts.map((contract) => {
+                            const available = Math.max(0, contract.amount - contract.reservedQuantity);
+                            const profitClass = contract.profit >= 0 ? "oc-profit--plus" : "oc-profit--minus";
+
+                            return (
+                                <tr key={`${contract.id}-${contract.holdingId}`}>
+                                    <td>
+                      <span className={`oc-status oc-status--${contract.status}`}>
+                        {statusLabel(contract.status)}
+                      </span>
+                                    </td>
+                                    <td className="oc-ticker">{contract.ticker}</td>
+                                    <td>{contract.name}</td>
+                                    <td>{optionTypeLabel(contract.optionType)}</td>
+                                    <td>{contract.amount}</td>
+                                    <td>{available}</td>
+                                    <td>
+                                        {contract.strikePrice > 0
+                                            ? formatCurrency(contract.strikePrice, contract.currency)
+                                            : "—"}
+                                    </td>
+                                    <td>{formatCurrency(contract.avgCost, contract.currency)}</td>
+                                    <td>{formatCurrency(contract.currentPrice, contract.currency)}</td>
+                                    <td className={`oc-profit ${profitClass}`}>
+                                        {contract.profit >= 0 ? "+" : ""}
+                                        {formatCurrency(contract.profit, contract.currency)}
+                                    </td>
+                                    <td>{formatDate(contract.settlementUnix)}</td>
+                                    <td>{contract.accountNumber}</td>
+                                    <td>{formatDateTime(contract.lastModifiedUnix)}</td>
+                                </tr>
+                            );
+                        })}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/router/AppRouter.jsx
+++ b/src/router/AppRouter.jsx
@@ -39,6 +39,7 @@ import ActuaryManagementPage from "../pages/ActuaryManagementPage.jsx";
 import CreateOrderPage from "../pages/CreateOrderPage.jsx";
 import MyOrdersPage from "../pages/MyOrdersPage.jsx";
 import OrdersReviewPage from "../pages/OrdersReviewPage.jsx";
+import OptionContractsPage from "../pages/OptionContractsPage.jsx";
 
 export default function AppRouter() {
   return (
@@ -83,6 +84,7 @@ export default function AppRouter() {
           {/* Order flow: create-on-form, my-history, supervisor review. */}
           <Route path="/orders/new" element={<ProtectedRoute><CreateOrderPage /></ProtectedRoute>} />
           <Route path="/orders/my" element={<ProtectedRoute><MyOrdersPage /></ProtectedRoute>} />
+          <Route path="/option-contracts" element={<ProtectedRoute><OptionContractsPage /></ProtectedRoute>} />
           <Route path="/orders/review" element={<ProtectedRoute requiredPermission="supervisor"><OrdersReviewPage /></ProtectedRoute>} />
 
           <Route path="/employees/create" element={<ProtectedRoute requiredRole="employee" requiredPermission="admin"><CreateEmployeePage /></ProtectedRoute>}/>

--- a/src/services/OptionContractsService.js
+++ b/src/services/OptionContractsService.js
@@ -1,0 +1,66 @@
+import { listPortfolio } from "./PortfolioService.js";
+
+const CENTS = 100;
+
+function toMajor(value) {
+    return (Number(value) || 0) / CENTS;
+}
+
+function readFirst(obj, keys, fallback = null) {
+    for (const key of keys) {
+        if (obj?.[key] !== undefined && obj?.[key] !== null) return obj[key];
+    }
+    return fallback;
+}
+
+function toUnixSeconds(value) {
+    if (!value) return null;
+    if (typeof value === "number") return value > 1e12 ? Math.floor(value / 1000) : value;
+
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? null : Math.floor(parsed / 1000);
+}
+
+function mapHoldingToOptionContract(h) {
+    const settlementUnix = toUnixSeconds(readFirst(h, [
+        "settlement_date",
+        "settlementDate",
+        "expiry_date",
+        "expiryDate",
+        "expiration_date",
+        "expirationDate",
+    ]));
+
+    const now = Math.floor(Date.now() / 1000);
+
+    return {
+        id: readFirst(h, ["option_id", "optionId", "id"]),
+        holdingId: h.id,
+        ticker: h.ticker || "—",
+        name: readFirst(h, ["name", "asset_name", "assetName"], "—"),
+        optionType: readFirst(h, ["option_type", "optionType", "type"], "—"),
+        amount: Number(readFirst(h, ["amount", "quantity"], 0)) || 0,
+        reservedQuantity: Number(readFirst(h, ["reserved_quantity", "reservedQuantity"], 0)) || 0,
+        avgCost: toMajor(readFirst(h, ["avg_cost", "avgCost"], 0)),
+        currentPrice: toMajor(readFirst(h, ["current_price", "currentPrice"], 0)),
+        profit: toMajor(readFirst(h, ["profit", "pnl"], 0)),
+        strikePrice: toMajor(readFirst(h, ["strike", "strike_price", "strikePrice"], 0)),
+        currency: readFirst(h, ["currency", "settlement_currency", "settlementCurrency"], "USD"),
+        settlementUnix,
+        lastModifiedUnix: toUnixSeconds(readFirst(h, ["last_modified_unix", "lastModifiedUnix", "updated_at", "updatedAt"])),
+        status: settlementUnix && settlementUnix < now ? "expired" : "valid",
+        accountNumber: readFirst(h, ["account_number", "accountNumber"], "—"),
+    };
+}
+
+export async function listSignedOptionContracts() {
+    const portfolio = await listPortfolio();
+    const holdings = Array.isArray(portfolio) ? portfolio : [];
+
+    return holdings
+        .filter((h) => {
+            const assetType = String(readFirst(h, ["asset_type", "assetType", "security_type", "securityType"], ""));
+            return assetType.toLowerCase() === "option";
+        })
+        .map(mapHoldingToOptionContract);
+}


### PR DESCRIPTION
## Description

Added a page for viewing all signed option contracts with filters for valid and expired contracts.

## Changes

- Added option contracts service
- Added option contracts overview page
- Added filters for all, valid and expired contracts
- Added search by ticker, name and account number
- Added route `/option-contracts`
- Added sidebar navigation entry under Trading

## Testing

- Verified that the frontend starts successfully
- Verified that the page renders and filters contracts based on expiration date

Closes #233 