### PR TITLE
fix(racuni): render counterparty account number, not the UUID

### DIFF
--- a/src/lib/api/generated/models/v1Transaction.ts
+++ b/src/lib/api/generated/models/v1Transaction.ts
@@ -25,5 +25,7 @@ export type v1Transaction = {
     initiatorClientId?: string;
     status?: v1TransactionStatus;
     createdAt?: string;
+    fromAccountNumber?: string;
+    toAccountNumber?: string;
 };
 

--- a/src/routes/_authed/banking/racuni/$id.tsx
+++ b/src/routes/_authed/banking/racuni/$id.tsx
@@ -252,14 +252,18 @@ function AccountDetail() {
             <TBody>
               {filteredTx.map((t) => {
                 const outflow = t.fromAccountId === id
-                const counterparty = outflow ? t.toAccountId : t.fromAccountId
+                const counterpartyNumber = outflow ? t.toAccountNumber : t.fromAccountNumber
                 const amount = outflow ? t.fromAmount : t.toAmount
                 return (
                   <TR key={t.id}>
                     <TD className="whitespace-nowrap text-xs text-muted-foreground">{formatDateTime(t.createdAt)}</TD>
                     <TD>{txKindLabel[t.kind!]}</TD>
                     <TD>{outflow ? 'Odliv' : 'Priliv'}</TD>
-                    <TD className="font-mono text-xs">{counterparty || '—'}</TD>
+                    <TD className="font-mono text-xs">
+                      {counterpartyNumber
+                        ? formatAccountNumber(counterpartyNumber)
+                        : t.recipientName || '—'}
+                    </TD>
                     <TD className="text-xs text-foreground">{t.purpose || t.recipientName || '—'}</TD>
                     <TD className={`text-right ${outflow ? 'text-danger' : 'text-success-soft-foreground'}`}>
                       {outflow ? '-' : '+'}


### PR DESCRIPTION
QA C3 journal: *"lista transakcija polje drugi račun prikazuje primary key računa umesto broja računa."*

Pairs with backend PR RAF-SI-2025/Banka-3-Backend `fix/tx-list-show-account-number` which adds `from/to_account_number` to the Transaction payload.

## Fix
- `racuni/$id.tsx`: render `formatAccountNumber(counterpartyNumber)` (server-resolved 18-digit number) instead of the raw `toAccountId/fromAccountId` UUID; fall back to `recipientName` then "—".
- `v1Transaction` model: add `fromAccountNumber`/`toAccountNumber` by hand (the openapi codegen binary is unavailable in-container) — matches the regenerated `banka.swagger.json` exactly.

## Verification
`make typecheck` (tsc -b --noEmit) clean. Backend live check confirms the fields populate (`toNo=333000176072044899`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)