### PR TITLE
fix(nalozi): supervisor can approve over-limit orders from the queue

### DIFF
--- a/src/routes/_authed/portal/trgovina/nalozi/index.tsx
+++ b/src/routes/_authed/portal/trgovina/nalozi/index.tsx
@@ -273,7 +273,10 @@ function RowActions({
                   variant="primary"
                   disabled={busy}
                   data-cy="approve-order"
-                  onClick={() => approve.mutate()}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    approve.mutate()
+                  }}
                 >
                   Odobri
                 </Button>
@@ -284,7 +287,10 @@ function RowActions({
                 variant="danger"
                 disabled={busy}
                 data-cy="decline-order"
-                onClick={() => decline.mutate()}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  decline.mutate()
+                }}
               >
                 Odbij
               </Button>
@@ -297,7 +303,10 @@ function RowActions({
               variant="outline"
               disabled={busy}
               data-cy="cancel-order"
-              onClick={() => cancel.mutate()}
+              onClick={(e) => {
+                e.stopPropagation()
+                cancel.mutate()
+              }}
             >
               Otkaži
             </Button>


### PR DESCRIPTION
QA C3 journal: *"Nakon što agent prekorači dnevni limit … „nalog ide na odobrenje supervizoru“ … supervizor nema način da odobri navedeni nalog."*

## Root cause — frontend, not backend
Backend verified correct **end to end** on the live stack:
- Agent (limit 200000 RSD) MARKET BUY 80 AAPL @ \$300.23 (~2.4M RSD) → `ORDER_STATUS_PENDING`.
- Supervisor `GET /api/v1/orders?status=pending` → returns it (count 1).
- Supervisor `POST /api/v1/orders/{id}/approve` → `ORDER_STATUS_APPROVED`, `approvedBy=<supervisor>`.

The pending-orders queue rows are fully clickable (`<TR onClick={navigate(detail)}>`). The `Odobri` / `Odbij` / `Otkaži` buttons had **no `stopPropagation`** — clicking `Odobri` fired `approve.mutate()` and then the click bubbled to the row `navigate()`, unmounting the component mid-request and whisking the supervisor to the detail page with no feedback. It looked like approve did nothing.

## Fix
`stopPropagation()` on the approve/decline/cancel button `onClick` handlers so the mutation runs in place with its error/refetch surfaced. (The detail page already has a working approve as the alternative path.)

`make typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)