### PR TITLE
fix(portfolio/trgovina): live-refresh detail pages after a sell

### DIFF
--- a/src/components/trading/ListingDetail.tsx
+++ b/src/components/trading/ListingDetail.tsx
@@ -64,8 +64,9 @@ export function ListingDetail({ listingId, basePath, initialDirection, initialQu
     queryFn: () => getSecurity(listingId),
     // Spec C3-tests S17: listing detail's price/ask/bid refresh on an
     // interval so the order form sees fresh quotes without a manual
-    // page reload.
-    refetchInterval: 30_000,
+    // page reload. Aligned to the portfolio cadence (5s) per the QA
+    // "auto-refresh na Trgovini kao na portfoliju".
+    refetchInterval: 5_000,
   })
 
   const sec = security.data?.security

--- a/src/components/trading/ListingsTable.tsx
+++ b/src/components/trading/ListingsTable.tsx
@@ -52,9 +52,11 @@ export function ListingsTable({ basePath, showForexAndOptions }: ListingsTablePr
   const securities = useQuery({
     queryKey: keys.security.list(args),
     queryFn: () => listSecurities(args),
-    // Spec C3-tests S17: catalog rows refresh on an interval without
-    // user action so price / volume / change stay live.
-    refetchInterval: 30_000,
+    // Spec C3-tests S17 + QA "auto-refresh na Trgovini kao na
+    // portfoliju": catalog rows refresh on an interval without user
+    // action so price / volume / change stay live. Aligned to the
+    // portfolio cadence (5s) so both screens feel equally live.
+    refetchInterval: 5_000,
   })
 
   const setKind = (k: v1SecurityType) => {

--- a/src/routes/_authed/banking/portfolio/$securityId.tsx
+++ b/src/routes/_authed/banking/portfolio/$securityId.tsx
@@ -27,6 +27,11 @@ function PositionDetail() {
   const security = useQuery({
     queryKey: keys.security.detail(securityId),
     queryFn: () => getSecurity(securityId),
+    // Live price + the holding below auto-refresh like the portfolio
+    // index (5s). Without this the per-security page stayed stale
+    // after a sell — the holding still looked unsold until a manual
+    // reload.
+    refetchInterval: 5_000,
   })
 
   const userId = useAuthStore((s) => s.userId) ?? ''
@@ -36,6 +41,7 @@ function PositionDetail() {
     queryKey: keys.portfolio.list(userId),
     queryFn: () => listHoldings(),
     enabled: Boolean(userId),
+    refetchInterval: 5_000,
   })
 
   const sec = security.data?.security


### PR DESCRIPTION
QA C3 journal — BUG "Na stranici portfolio, nakon što je hartija prodata UI nije osvežen i izgleda kao da hartija nije prodata iako jeste" + TODO "Dodati automatsko osvežavanje na stranici Trgovina isto kao na portfoliju".

## Triage
The portfolio **index** already auto-refreshes (`refetchInterval: 5_000`) and `OrderForm` invalidates `keys.portfolio.all` on success — so that path was fine. The real gaps:
- **banking/portfolio/$securityId** (per-security detail: holding + realized P&L) had **no** `refetchInterval`. A SELL fills asynchronously (partial-fill cadence); the detail page kept showing the old quantity until a manual reload → exactly the QA symptom.
- Trgovina catalog (`ListingsTable`) + detail (`ListingDetail`) refreshed every **30s**, out of step with the portfolio's 5s.

## Fix (FE-only)
- portfolio `$securityId`: `holdings` + `security` queries → `refetchInterval: 5_000` (parity with the index).
- `ListingsTable` + `ListingDetail`: 30s → 5s, so Trgovina is as live as the portfolio per the QA TODO.

`tsc -b --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)