### PR TITLE
fix(auth): await cookie session restore in /_authed guard (S35)

### DIFF
--- a/src/lib/auth/use-auth.ts
+++ b/src/lib/auth/use-auth.ts
@@ -13,48 +13,71 @@ interface MeBody {
   client?: { id: string; permissions: string[]; firstName?: string; lastName?: string }
 }
 
-/**
- * useBootstrapAuth tries to restore a session on app start: ask the
- * gateway to refresh (cookie-only) and, on success, hydrate the store.
- * Returns true once the bootstrap attempt has finished (success or
- * failure) so route guards can avoid flashing the login screen.
- */
-export function useBootstrapAuth(): boolean {
-  const [ready, setReady] = useState(false)
-  const setLogin = useAuthStore((s) => s.setLogin)
-  const clear = useAuthStore((s) => s.clear)
+// One in-flight restore per page load. Both the __root bootstrap and
+// the /_authed route guard call restoreSession(); memoising the promise
+// means a single /auth/refresh round-trip serves all callers and — the
+// load-bearing part — the guard can *await* the same restore the
+// bootstrap does instead of racing it (S35: a valid refresh-cookie
+// session was bounced to /login on reload because the synchronous
+// guard ran before the useEffect bootstrap).
+let restorePromise: Promise<boolean> | null = null
 
-  useEffect(() => {
-    let cancelled = false
-    ;(async () => {
+/**
+ * restoreSession ensures the auth store reflects the current session.
+ *
+ * No-op (true) if an access token is already in the store. Otherwise
+ * it asks the gateway to refresh using the httpOnly cookie (JS can't
+ * read it) and hydrates identity from /auth/me on success. The
+ * cookie-refresh runs at most once per page load (concurrent callers
+ * share it); the up-front accessToken check means logging back in
+ * within the same tab works without a reload.
+ */
+export async function restoreSession(): Promise<boolean> {
+  if (useAuthStore.getState().accessToken) return true
+  if (!restorePromise) {
+    restorePromise = (async () => {
       try {
         const { data } = await api.post<RefreshBody>('/v1/auth/refresh')
         const me = await api.get<MeBody>('/v1/auth/me', {
           headers: { Authorization: `Bearer ${data.accessToken}` },
         })
-        if (cancelled) return
         const perms = jwtDecodePermissions(data.accessToken) ?? []
         const principal = me.data.employee ?? me.data.client
-        const userId = principal?.id ?? ''
-        const userKind: 'employee' | 'client' = me.data.employee ? 'employee' : 'client'
-        setLogin({
+        useAuthStore.getState().setLogin({
           accessToken: data.accessToken,
-          userId,
-          userKind,
+          userId: principal?.id ?? '',
+          userKind: me.data.employee ? 'employee' : 'client',
           permissions: perms,
           firstName: principal?.firstName,
           lastName: principal?.lastName,
         })
+        return true
       } catch {
-        if (!cancelled) clear()
-      } finally {
-        if (!cancelled) setReady(true)
+        useAuthStore.getState().clear()
+        return false
       }
     })()
+  }
+  return restorePromise
+}
+
+/**
+ * useBootstrapAuth tries to restore a session on app start and returns
+ * true once the attempt has finished (success or failure) so the root
+ * layout can hold the first paint and avoid flashing the login screen.
+ */
+export function useBootstrapAuth(): boolean {
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    restoreSession().finally(() => {
+      if (!cancelled) setReady(true)
+    })
     return () => {
       cancelled = true
     }
-  }, [setLogin, clear])
+  }, [])
 
   return ready
 }

--- a/src/routes/_authed.tsx
+++ b/src/routes/_authed.tsx
@@ -1,11 +1,19 @@
 import { useEffect } from 'react'
 import { createFileRoute, Outlet, redirect, useNavigate } from '@tanstack/react-router'
 import { useAuthStore } from '@/lib/auth/store'
+import { restoreSession } from '@/lib/auth/use-auth'
 
 export const Route = createFileRoute('/_authed')({
-  beforeLoad: () => {
-    const { accessToken } = useAuthStore.getState()
-    if (!accessToken) throw redirect({ to: '/login' })
+  // Await the cookie-based session restore before deciding. The store
+  // is sessionStorage-backed (empty after a fresh load / closed tab),
+  // so a synchronous accessToken check here redirected to /login
+  // before the refresh-cookie bootstrap could run — a valid session
+  // looked dead on reload (S35). restoreSession() is memoised, so this
+  // shares the one /auth/refresh the root bootstrap already performs.
+  beforeLoad: async () => {
+    if (!(await restoreSession())) {
+      throw redirect({ to: '/login' })
+    }
   },
   component: AuthedShell,
 })


### PR DESCRIPTION
QA C3 journal S35: *"Ne radi jer sesije … local storage nije uvek nužno populisan access i refresh tokenima."*

## Root cause (a race, not localStorage)
By design the auth store is **sessionStorage**-backed (spec p.10: closing the browser forces re-login) and the refresh token is an httpOnly cookie JS can't read — so the tester's "localStorage" expectation was off, but the symptom was real. `/_authed.beforeLoad` **synchronously** checked the in-store access token and `redirect({to:'/login'})` when absent. The cookie-based restore (`useBootstrapAuth`) only ran afterwards, in a `useEffect` inside `RootLayout`. On a hard reload sessionStorage is empty, so the guard fired **before** the refresh could run → a perfectly valid refresh-cookie session was bounced to `/login`. "Sesije ne rade."

## Fix (FE-only)
- Extract `restoreSession()` — a per-page-load **memoised** `/auth/refresh` (+ `/auth/me`) hydrate. `useBootstrapAuth` delegates to it.
- `/_authed.beforeLoad` is now `async` and **awaits** `restoreSession()`; it only redirects to `/login` when there is genuinely no session. Both callers share the one refresh round-trip; an existing in-store token short-circuits so post-login navigation adds no call.

## Verified on the live stack
`login` sets the refresh cookie → `POST /api/v1/auth/refresh` with **cookie only, no Authorization header** → fresh access token → `/api/v1/auth/me` → principal + permissions. The fix makes the guard await exactly this. `tsc -b --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
