### PR TITLE
feat(funds): discovery statistics + performance chart (todoSpec S73-S77)

### DIFF
--- a/src/components/funds/FundDetail.tsx
+++ b/src/components/funds/FundDetail.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useMemo, useState } from 'react'
+import { useQueries, useQuery } from '@tanstack/react-query'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Table, THead, TBody, TR, TH, TD, EmptyRow } from '@/components/ui/table'
 import { Button } from '@/components/ui/button'
 import { ErrorBanner } from '@/components/ui/error'
-import { getFund, getFundPerformance } from '@/lib/api/funds'
+import { getFund, getFundPerformance, listFunds } from '@/lib/api/funds'
+import { buildAverageSeries } from '@/lib/funds/average'
 import { keys } from '@/lib/query-keys'
 import { useAuthStore } from '@/lib/auth/store'
 import { Permissions, has } from '@/lib/permissions'
@@ -41,6 +42,26 @@ export function FundDetail({ fundId }: Props) {
     staleTime: 5 * 60_000,
   })
 
+  // For the S75 comparison line we need every fund's value history. Fetch
+  // the universe, then each fund's performance (the viewed fund's own
+  // query is deduped via the shared performance key).
+  const allFundsQ = useQuery({
+    queryKey: keys.funds.list({ status: 'active', for: 'avg' }),
+    queryFn: () => listFunds({ status: 'active' }),
+    staleTime: 5 * 60_000,
+  })
+  const allFundIds = useMemo(
+    () => (allFundsQ.data?.funds ?? []).map((f) => f.id).filter((id): id is string => Boolean(id)),
+    [allFundsQ.data],
+  )
+  const allPerfQ = useQueries({
+    queries: allFundIds.map((id) => ({
+      queryKey: keys.funds.performance(id, 365),
+      queryFn: () => getFundPerformance(id, 365),
+      staleTime: 5 * 60_000,
+    })),
+  })
+
   const [investOpen, setInvestOpen] = useState(false)
   const [withdrawOpen, setWithdrawOpen] = useState(false)
   const [buyOpen, setBuyOpen] = useState(false)
@@ -60,6 +81,13 @@ export function FundDetail({ fundId }: Props) {
 
   const { fund, holdings = [], position } = fundQ.data
   const snapshots = perfQ.data?.snapshots ?? []
+  // Average-of-all-funds overlay (S75): only meaningful with >1 fund and
+  // once the universe's histories have loaded.
+  const otherSeries = allPerfQ.map((r) => r.data?.snapshots ?? [])
+  const avgSeries =
+    snapshots.length > 0 && allFundIds.length > 1
+      ? buildAverageSeries(snapshots, otherSeries)
+      : undefined
 
   return (
     <main className="container space-y-6 py-8">
@@ -139,7 +167,7 @@ export function FundDetail({ fundId }: Props) {
           {snapshots.length === 0 ? (
             <p className="text-sm text-muted-foreground">Još nema istorije performansa.</p>
           ) : (
-            <FundPerformanceChart rows={snapshots} />
+            <FundPerformanceChart rows={snapshots} avg={avgSeries} />
           )}
         </CardContent>
       </Card>

--- a/src/components/funds/FundPerformanceChart.tsx
+++ b/src/components/funds/FundPerformanceChart.tsx
@@ -3,17 +3,37 @@ import type { v1FundPerformanceSnapshot } from '@/lib/api/generated/models/v1Fun
 // Hand-rolled SVG line chart of total_value_rsd over time. Matches
 // the look of PriceHistoryChart. The snapshot cron writes one row
 // daily so the series is dense enough to draw without smoothing.
+//
+// An optional `avg` overlay (todoSpec S75) draws the average of all
+// funds' value over the same time window as a dashed comparison line.
+// Both series are scaled to the combined min/max so the comparison is
+// visually honest.
 const W = 720
 const H = 200
 const PAD_X = 40
 const PAD_Y = 12
 
-export function FundPerformanceChart({ rows }: { rows: v1FundPerformanceSnapshot[] }) {
+export interface AvgPoint {
+  /** ISO timestamp (must line up with the fund's snapshot timestamps). */
+  t: string
+  /** average total value across all funds in RSD at that instant. */
+  value: number
+}
+
+export function FundPerformanceChart({
+  rows,
+  avg,
+}: {
+  rows: v1FundPerformanceSnapshot[]
+  avg?: AvgPoint[]
+}) {
   if (rows.length === 0) return null
 
   const values = rows.map((r) => Number(r.totalValueRsd ?? '0'))
-  const vMin = Math.min(...values)
-  const vMax = Math.max(...values)
+  const avgValues = (avg ?? []).map((p) => p.value).filter((v) => Number.isFinite(v))
+  const all = [...values, ...avgValues]
+  const vMin = Math.min(...all)
+  const vMax = Math.max(...all)
   const span = Math.max(1e-6, vMax - vMin)
   const usableW = W - PAD_X * 2
   const stepX = rows.length > 1 ? usableW / (rows.length - 1) : 0
@@ -24,13 +44,51 @@ export function FundPerformanceChart({ rows }: { rows: v1FundPerformanceSnapshot
     .map((v, i) => `${i === 0 ? 'M' : 'L'} ${xAt(i).toFixed(1)} ${yAt(v).toFixed(1)}`)
     .join(' ')
 
+  // The avg line is index-aligned to the fund's own snapshot rows so the
+  // two lines share an x-axis; gaps (no avg value for that index) break
+  // the path into separate move segments.
+  const avgPath =
+    avg && avg.length > 0
+      ? avg
+          .map((p, i) =>
+            Number.isFinite(p.value)
+              ? `${i === 0 ? 'M' : 'L'} ${xAt(i).toFixed(1)} ${yAt(p.value).toFixed(1)}`
+              : '',
+          )
+          .filter(Boolean)
+          .join(' ')
+      : ''
+
   return (
-    <svg viewBox={`0 0 ${W} ${H}`} className="w-full max-w-full" role="img" aria-label="Performans fonda">
-      <line x1={PAD_X} x2={W - PAD_X} y1={H - PAD_Y} y2={H - PAD_Y} className="stroke-border" strokeWidth={1} />
-      <line x1={PAD_X} x2={W - PAD_X} y1={PAD_Y} y2={PAD_Y} className="stroke-border" strokeDasharray="2 4" strokeWidth={1} />
-      <text x={4} y={PAD_Y + 4} className="fill-muted-foreground text-[10px]">{vMax.toFixed(0)}</text>
-      <text x={4} y={H - PAD_Y} className="fill-muted-foreground text-[10px]">{vMin.toFixed(0)}</text>
-      <path d={path} className="stroke-primary" strokeWidth={1.5} fill="none" />
-    </svg>
+    <div className="space-y-2">
+      <svg viewBox={`0 0 ${W} ${H}`} className="w-full max-w-full" role="img" aria-label="Performans fonda">
+        <line x1={PAD_X} x2={W - PAD_X} y1={H - PAD_Y} y2={H - PAD_Y} className="stroke-border" strokeWidth={1} />
+        <line x1={PAD_X} x2={W - PAD_X} y1={PAD_Y} y2={PAD_Y} className="stroke-border" strokeDasharray="2 4" strokeWidth={1} />
+        <text x={4} y={PAD_Y + 4} className="fill-muted-foreground text-[10px]">{vMax.toFixed(0)}</text>
+        <text x={4} y={H - PAD_Y} className="fill-muted-foreground text-[10px]">{vMin.toFixed(0)}</text>
+        {avgPath && (
+          <path
+            d={avgPath}
+            className="stroke-muted-foreground"
+            strokeWidth={1.25}
+            strokeDasharray="4 3"
+            fill="none"
+            data-cy="fund-perf-avg-line"
+          />
+        )}
+        <path d={path} className="stroke-primary" strokeWidth={1.5} fill="none" data-cy="fund-perf-line" />
+      </svg>
+      {avgPath && (
+        <div className="flex items-center gap-4 text-xs text-muted-foreground">
+          <span className="inline-flex items-center gap-1.5">
+            <span className="inline-block h-0.5 w-4 bg-primary" /> Ovaj fond
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            <span className="inline-block h-0.5 w-4 border-t border-dashed border-muted-foreground" />
+            Prosek svih fondova
+          </span>
+        </div>
+      )}
+    </div>
   )
 }

--- a/src/components/funds/FundsDiscovery.tsx
+++ b/src/components/funds/FundsDiscovery.tsx
@@ -5,22 +5,51 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Table, THead, TBody, TR, TH, TD, EmptyRow } from '@/components/ui/table'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Select } from '@/components/ui/select'
 import { Button } from '@/components/ui/button'
 import { listFunds, type ListFundsArgs } from '@/lib/api/funds'
 import { keys } from '@/lib/query-keys'
 import { formatMoney } from '@/lib/format'
 import { useAuthStore } from '@/lib/auth/store'
 import { Permissions, has } from '@/lib/permissions'
+import { useFundMetrics } from '@/lib/funds/useFundMetrics'
+import type { FundMetrics } from '@/lib/funds/metrics'
 import { CreateFundDialog } from './CreateFundDialog'
 
 interface Props {
   basePath: '/portal/fondovi' | '/banking/fondovi'
 }
 
-// Spec p.71 "Investicioni fondovi — pregled". Supervisors (with
-// funds.manage.supervisor) see the "Kreiraj fond" button; everyone
-// else is read-only. Click row → detail.
+// Sort keys: the four name/value/profit/min columns map to numeric or
+// string fields on the fund; the four statistics columns sort on the
+// client-computed metrics (todoSpec S73/S76/S77). Metrics that are
+// unavailable (insufficient history) always sort to the bottom.
+type SortKey =
+  | 'name'
+  | 'total_value'
+  | 'profit'
+  | 'minimum_contribution'
+  | 'annualReturn'
+  | 'sharpe'
+  | 'maxDrawdown'
+  | 'volatility'
+type SortDir = 'asc' | 'desc'
+
+function fmtPct(v: number | null): string {
+  if (v == null) return '—'
+  return `${(v * 100).toFixed(2)}%`
+}
+
+function fmtRatio(v: number | null): string {
+  if (v == null) return '—'
+  return v.toFixed(2)
+}
+
+// Spec p.71 "Investicioni fondovi — pregled" + todoSpec S73. Supervisors
+// (with funds.manage.supervisor) see the "Kreiraj fond" button; everyone
+// else is read-only. Discovery shows fund value/profit plus four risk
+// statistics (godišnji prinos / Sharpe / Max Drawdown / Volatilnost),
+// each column sortable; unavailable metrics render "—" (S74). Click row →
+// detail.
 export function FundsDiscovery({ basePath }: Props) {
   const navigate = useNavigate()
   const perms = useAuthStore((s) => s.permissions)
@@ -32,19 +61,23 @@ export function FundsDiscovery({ basePath }: Props) {
     }
   }
   const canManage = has(perms, Permissions.FundsManageSupervisor)
-  const [sort, setSort] = useState<NonNullable<ListFundsArgs['sort']>>('name')
-  const [order, setOrder] = useState<NonNullable<ListFundsArgs['order']>>('asc')
+  // Default to godišnji prinos descending (S76 is the canonical default view).
+  const [sortKey, setSortKey] = useState<SortKey>('annualReturn')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
   const [minAtLeast, setMinAtLeast] = useState('')
   const [createOpen, setCreateOpen] = useState(false)
 
+  // The list endpoint sorts server-side, but the statistics are computed
+  // client-side, so we fetch with a stable order and do all ordering here
+  // to keep every column sortable uniformly.
   const args = useMemo<ListFundsArgs>(
     () => ({
       status: 'active',
-      sort,
-      order,
+      sort: 'name',
+      order: 'asc',
       minContributionAtLeast: minAtLeast.trim() || undefined,
     }),
-    [sort, order, minAtLeast],
+    [minAtLeast],
   )
 
   const q = useQuery({
@@ -54,7 +87,83 @@ export function FundsDiscovery({ basePath }: Props) {
     refetchInterval: 5_000,
   })
 
-  const rows = q.data?.funds ?? []
+  const funds = useMemo(() => q.data?.funds ?? [], [q.data])
+  const metrics = useFundMetrics(funds.map((f) => f.id))
+
+  const toggleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortKey(key)
+      // Numbers default to descending (biggest first); name to ascending.
+      setSortDir(key === 'name' ? 'asc' : 'desc')
+    }
+  }
+
+  const rows = useMemo(() => {
+    const metricField: Record<string, keyof FundMetrics> = {
+      annualReturn: 'annualReturn',
+      sharpe: 'sharpe',
+      maxDrawdown: 'maxDrawdown',
+      volatility: 'volatility',
+    }
+    const valueOf = (f: (typeof funds)[number]): number | string | null => {
+      switch (sortKey) {
+        case 'name':
+          return (f.name ?? '').toLowerCase()
+        case 'total_value':
+          return Number(f.totalValueRsd ?? '0')
+        case 'profit':
+          return Number(f.profitRsd ?? '0')
+        case 'minimum_contribution':
+          return Number(f.minimumContribution ?? '0')
+        default: {
+          const m = metrics.get(f.id)
+          return m[metricField[sortKey]] as number | null
+        }
+      }
+    }
+    const dir = sortDir === 'asc' ? 1 : -1
+    return [...funds].sort((a, b) => {
+      const va = valueOf(a)
+      const vb = valueOf(b)
+      // null (unavailable metric) always sinks to the bottom regardless of dir.
+      if (va == null && vb == null) return 0
+      if (va == null) return 1
+      if (vb == null) return -1
+      if (typeof va === 'string' && typeof vb === 'string') {
+        return va.localeCompare(vb, 'sr-RS') * dir
+      }
+      return ((va as number) - (vb as number)) * dir
+    })
+  }, [funds, metrics, sortKey, sortDir])
+
+  const arrow = (key: SortKey) => (sortKey === key ? (sortDir === 'asc' ? ' ▲' : ' ▼') : '')
+
+  function SortTH({
+    label,
+    sortKeyName,
+    className,
+    cy,
+  }: {
+    label: string
+    sortKeyName: SortKey
+    className?: string
+    cy: string
+  }) {
+    return (
+      <TH
+        className={`cursor-pointer select-none hover:text-foreground ${className ?? ''}`}
+        onClick={() => toggleSort(sortKeyName)}
+        aria-sort={sortKey === sortKeyName ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
+        data-cy={`funds-sort-${cy}`}
+        data-cy-active={sortKey === sortKeyName ? sortDir : undefined}
+      >
+        {label}
+        {arrow(sortKeyName)}
+      </TH>
+    )
+  }
 
   return (
     <main className="container space-y-6 py-8">
@@ -62,7 +171,8 @@ export function FundsDiscovery({ basePath }: Props) {
         <div>
           <h1 className="text-2xl font-semibold">Investicioni fondovi</h1>
           <p className="text-sm text-muted-foreground">
-            Aktivni fondovi banke. Kliknite na red za detalje, ulaganje ili povlačenje.
+            Aktivni fondovi banke sa statistikom prinosa i rizika. Kliknite na zaglavlje
+            kolone za sortiranje, na red za detalje.
           </p>
         </div>
         {canManage && (
@@ -84,32 +194,6 @@ export function FundsDiscovery({ basePath }: Props) {
         <CardContent>
           <div className="grid grid-cols-1 gap-3 md:grid-cols-4">
             <div>
-              <Label htmlFor="funds-sort">Sortiraj po</Label>
-              <Select
-                id="funds-sort"
-                value={sort}
-                onChange={(e) => setSort(e.target.value as NonNullable<ListFundsArgs['sort']>)}
-                data-cy="funds-sort"
-              >
-                <option value="name">Naziv</option>
-                <option value="total_value">Ukupna vrednost</option>
-                <option value="profit">Profit</option>
-                <option value="minimum_contribution">Min. uplata</option>
-              </Select>
-            </div>
-            <div>
-              <Label htmlFor="funds-order">Smer</Label>
-              <Select
-                id="funds-order"
-                value={order}
-                onChange={(e) => setOrder(e.target.value as NonNullable<ListFundsArgs['order']>)}
-                data-cy="funds-order"
-              >
-                <option value="asc">Rastuće</option>
-                <option value="desc">Opadajuće</option>
-              </Select>
-            </div>
-            <div>
               <Label htmlFor="funds-min-at-least">Min. uplata ≥ (RSD)</Label>
               <Input
                 id="funds-min-at-least"
@@ -129,23 +213,64 @@ export function FundsDiscovery({ basePath }: Props) {
           <Table>
             <THead>
               <TR>
-                <TH>Naziv</TH>
+                <SortTH label="Naziv" sortKeyName="name" cy="name" />
                 <TH>Opis</TH>
-                <TH className="text-right">Ukupna vrednost</TH>
-                <TH className="text-right">Profit</TH>
-                <TH className="text-right">Min. uplata</TH>
+                <SortTH
+                  label="Ukupna vrednost"
+                  sortKeyName="total_value"
+                  className="text-right"
+                  cy="total-value"
+                />
+                <SortTH label="Profit" sortKeyName="profit" className="text-right" cy="profit" />
+                <SortTH
+                  label="Min. uplata"
+                  sortKeyName="minimum_contribution"
+                  className="text-right"
+                  cy="min"
+                />
+                <SortTH
+                  label="Godišnji prinos"
+                  sortKeyName="annualReturn"
+                  className="text-right"
+                  cy="annual-return"
+                />
+                <SortTH
+                  label="Reward-to-variability"
+                  sortKeyName="sharpe"
+                  className="text-right"
+                  cy="sharpe"
+                />
+                <SortTH
+                  label="Max Drawdown"
+                  sortKeyName="maxDrawdown"
+                  className="text-right"
+                  cy="max-drawdown"
+                />
+                <SortTH
+                  label="Volatilnost"
+                  sortKeyName="volatility"
+                  className="text-right"
+                  cy="volatility"
+                />
                 <TH>{/* actions */}</TH>
               </TR>
             </THead>
             <TBody>
               {rows.length === 0 ? (
-                <EmptyRow colSpan={6}>
+                <EmptyRow colSpan={10}>
                   {q.isFetching ? 'Učitavanje…' : 'Nema fondova.'}
                 </EmptyRow>
               ) : (
                 rows.map((f) => {
                   const profit = Number(f.profitRsd ?? '0')
                   const profitColor = profit >= 0 ? 'text-emerald-600' : 'text-rose-600'
+                  const m = metrics.get(f.id)
+                  const arColor =
+                    m.annualReturn == null
+                      ? 'text-muted-foreground'
+                      : m.annualReturn >= 0
+                        ? 'text-emerald-600'
+                        : 'text-rose-600'
                   return (
                     <TR
                       key={f.id}
@@ -156,12 +281,34 @@ export function FundsDiscovery({ basePath }: Props) {
                       }}
                     >
                       <TD className="font-medium">{f.name ?? '—'}</TD>
-                      <TD className="max-w-md truncate text-muted-foreground">{f.description ?? '—'}</TD>
-                      <TD className="text-right tabular-nums">{formatMoney(f.totalValueRsd, 'RSD')}</TD>
+                      <TD className="max-w-xs truncate text-muted-foreground">
+                        {f.description ?? '—'}
+                      </TD>
+                      <TD className="text-right tabular-nums">
+                        {formatMoney(f.totalValueRsd, 'RSD')}
+                      </TD>
                       <TD className={`text-right tabular-nums ${profitColor}`}>
                         {formatMoney(f.profitRsd, 'RSD')}
                       </TD>
-                      <TD className="text-right tabular-nums">{formatMoney(f.minimumContribution, 'RSD')}</TD>
+                      <TD className="text-right tabular-nums">
+                        {formatMoney(f.minimumContribution, 'RSD')}
+                      </TD>
+                      <TD
+                        className={`text-right tabular-nums ${arColor}`}
+                        data-cy="fund-annual-return"
+                        title={m.insufficient ? 'Nedovoljno istorije za izračun' : undefined}
+                      >
+                        {fmtPct(m.annualReturn)}
+                      </TD>
+                      <TD className="text-right tabular-nums" data-cy="fund-sharpe">
+                        {fmtRatio(m.sharpe)}
+                      </TD>
+                      <TD className="text-right tabular-nums" data-cy="fund-max-drawdown">
+                        {fmtPct(m.maxDrawdown)}
+                      </TD>
+                      <TD className="text-right tabular-nums" data-cy="fund-volatility">
+                        {fmtPct(m.volatility)}
+                      </TD>
                       <TD>
                         <Button
                           type="button"
@@ -181,6 +328,10 @@ export function FundsDiscovery({ basePath }: Props) {
               )}
             </TBody>
           </Table>
+          <p className="mt-3 text-xs text-muted-foreground">
+            Statistika se računa iz istorije vrednosti fonda. Fondovi sa nedovoljno
+            istorije prikazuju „—“. Reward-to-variability koristi nerizičnu stopu od 0%.
+          </p>
         </CardContent>
       </Card>
 

--- a/src/lib/funds/average.test.ts
+++ b/src/lib/funds/average.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { buildAverageSeries } from './average'
+
+describe('buildAverageSeries (S75)', () => {
+  const base = [
+    { snapshotAt: '2026-01-01T12:00:00Z', totalValueRsd: '100' },
+    { snapshotAt: '2026-01-02T12:00:00Z', totalValueRsd: '200' },
+  ]
+
+  it('averages across funds per day, aligned to the base series', () => {
+    const others = [
+      base,
+      [
+        { snapshotAt: '2026-01-01T09:00:00Z', totalValueRsd: '300' },
+        { snapshotAt: '2026-01-02T09:00:00Z', totalValueRsd: '400' },
+      ],
+    ]
+    const avg = buildAverageSeries(base, others)
+    expect(avg).toHaveLength(2)
+    expect(avg[0].value).toBeCloseTo((100 + 300) / 2, 10) // day 1
+    expect(avg[1].value).toBeCloseTo((200 + 400) / 2, 10) // day 2
+  })
+
+  it('buckets by calendar day so different snapshot times still align', () => {
+    const others = [[{ snapshotAt: '2026-01-01T23:30:00Z', totalValueRsd: '500' }]]
+    const avg = buildAverageSeries(base, others)
+    expect(avg[0].value).toBe(500)
+  })
+
+  it('yields NaN for a day no fund has data for', () => {
+    const avg = buildAverageSeries(base, [
+      [{ snapshotAt: '2026-01-01T12:00:00Z', totalValueRsd: '300' }],
+    ])
+    expect(avg[0].value).toBe(300)
+    expect(Number.isNaN(avg[1].value)).toBe(true)
+  })
+
+  it('ignores non-positive / NaN values', () => {
+    const avg = buildAverageSeries(base, [
+      [
+        { snapshotAt: '2026-01-01T12:00:00Z', totalValueRsd: '0' },
+        { snapshotAt: '2026-01-01T12:00:00Z', totalValueRsd: '600' },
+      ],
+    ])
+    expect(avg[0].value).toBe(600)
+  })
+})

--- a/src/lib/funds/average.ts
+++ b/src/lib/funds/average.ts
@@ -1,0 +1,52 @@
+// Builds the "average of all funds" comparison series (todoSpec S75)
+// aligned to a base fund's snapshot timestamps. Each fund's snapshots
+// are keyed by day; for every day in the base fund's series we average
+// the total value across whichever funds have a snapshot that day.
+
+import type { v1FundPerformanceSnapshot } from '@/lib/api/generated/models/v1FundPerformanceSnapshot'
+
+export interface AvgPoint {
+  t: string
+  value: number
+}
+
+/** YYYY-MM-DD bucket so snapshots taken at slightly different times still align. */
+function dayKey(iso: string | undefined): string {
+  if (!iso) return ''
+  const ms = Date.parse(iso)
+  return Number.isFinite(ms) ? new Date(ms).toISOString().slice(0, 10) : ''
+}
+
+/**
+ * @param base   the snapshots of the fund being viewed (defines the x-axis).
+ * @param others one snapshot list per fund in the universe (may include base).
+ * @returns one AvgPoint per base snapshot; value is NaN when no fund has data
+ *          for that day (the chart breaks the line there).
+ */
+export function buildAverageSeries(
+  base: ReadonlyArray<v1FundPerformanceSnapshot>,
+  others: ReadonlyArray<ReadonlyArray<v1FundPerformanceSnapshot>>,
+): AvgPoint[] {
+  // day -> { sum, count } across all funds.
+  const byDay = new Map<string, { sum: number; count: number }>()
+  for (const series of others) {
+    for (const snap of series) {
+      const k = dayKey(snap.snapshotAt)
+      const v = Number(snap.totalValueRsd ?? 'NaN')
+      if (!k || !Number.isFinite(v) || v <= 0) continue
+      const cur = byDay.get(k) ?? { sum: 0, count: 0 }
+      cur.sum += v
+      cur.count += 1
+      byDay.set(k, cur)
+    }
+  }
+
+  return base.map((snap) => {
+    const k = dayKey(snap.snapshotAt)
+    const agg = byDay.get(k)
+    return {
+      t: snap.snapshotAt ?? '',
+      value: agg && agg.count > 0 ? agg.sum / agg.count : NaN,
+    }
+  })
+}

--- a/src/lib/funds/metrics.test.ts
+++ b/src/lib/funds/metrics.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MIN_SNAPSHOTS,
+  computeFundMetrics,
+  maxDrawdown,
+  metricsFromSnapshots,
+  toSeries,
+  annualizedReturn,
+  type FundSnapshotPoint,
+} from './metrics'
+
+// Build a series spaced one day apart starting at a fixed date.
+function days(values: number[]): FundSnapshotPoint[] {
+  const start = Date.parse('2026-01-01T00:00:00Z')
+  return values.map((value, i) => ({
+    t: new Date(start + i * 86_400_000).toISOString(),
+    value,
+  }))
+}
+
+describe('toSeries', () => {
+  it('sorts ascending by time and drops bad rows', () => {
+    const s = toSeries([
+      { snapshotAt: '2026-01-03T00:00:00Z', totalValueRsd: '300' },
+      { snapshotAt: '2026-01-01T00:00:00Z', totalValueRsd: '100' },
+      { snapshotAt: '2026-01-02T00:00:00Z', totalValueRsd: '200' },
+      { snapshotAt: '', totalValueRsd: '999' }, // no timestamp
+      { snapshotAt: '2026-01-04T00:00:00Z', totalValueRsd: '0' }, // non-positive
+      { snapshotAt: '2026-01-05T00:00:00Z', totalValueRsd: 'abc' }, // NaN
+    ])
+    expect(s.map((p) => p.value)).toEqual([100, 200, 300])
+  })
+})
+
+describe('insufficient data (S74)', () => {
+  it('returns null metrics for fewer than MIN_SNAPSHOTS points', () => {
+    const m = computeFundMetrics(days([100, 110]))
+    expect(MIN_SNAPSHOTS).toBe(3)
+    expect(m.insufficient).toBe(true)
+    expect(m.annualReturn).toBeNull()
+    expect(m.volatility).toBeNull()
+    expect(m.sharpe).toBeNull()
+    expect(m.maxDrawdown).toBeNull()
+  })
+
+  it('returns null metrics for an empty series', () => {
+    expect(computeFundMetrics([]).insufficient).toBe(true)
+  })
+
+  it('metricsFromSnapshots also flags insufficient', () => {
+    const m = metricsFromSnapshots([{ snapshotAt: '2026-01-01T00:00:00Z', totalValueRsd: '100' }])
+    expect(m.insufficient).toBe(true)
+  })
+})
+
+describe('maxDrawdown (S77)', () => {
+  it('is zero for a monotonically rising series', () => {
+    expect(maxDrawdown([100, 110, 120, 130])).toBe(0)
+  })
+
+  it('captures the deepest peak-to-trough decline', () => {
+    // peak 200 holds across the whole window; deepest trough is 90 → 200→90 = 55%
+    expect(maxDrawdown([100, 200, 150, 100, 120, 90, 120])).toBeCloseTo(0.55, 10)
+  })
+
+  it('recovers the peak before a new drawdown window', () => {
+    // peak 100 → 80 (20%), then up to 300, then 300 → 240 (20%)
+    expect(maxDrawdown([100, 80, 300, 240])).toBeCloseTo(0.2, 10)
+  })
+})
+
+describe('annualizedReturn (S76)', () => {
+  it('annualizes a one-year doubling to ~100%', () => {
+    const s: FundSnapshotPoint[] = [
+      { t: '2025-01-01T00:00:00Z', value: 100 },
+      { t: '2026-01-01T00:00:00Z', value: 200 },
+    ]
+    const r = annualizedReturn(s)
+    expect(r).not.toBeNull()
+    expect(r as number).toBeCloseTo(1.0, 2)
+  })
+
+  it('is negative for a declining fund', () => {
+    const r = annualizedReturn([
+      { t: '2025-01-01T00:00:00Z', value: 200 },
+      { t: '2026-01-01T00:00:00Z', value: 150 },
+    ])
+    expect(r as number).toBeLessThan(0)
+  })
+
+  it('returns null for a zero-span series', () => {
+    expect(
+      annualizedReturn([
+        { t: '2026-01-01T00:00:00Z', value: 100 },
+        { t: '2026-01-01T00:00:00Z', value: 200 },
+      ]),
+    ).toBeNull()
+  })
+})
+
+describe('computeFundMetrics happy path', () => {
+  it('computes all four metrics for a sufficient series', () => {
+    const m = computeFundMetrics(days([100, 110, 105, 120, 130]))
+    expect(m.insufficient).toBe(false)
+    expect(m.annualReturn).not.toBeNull()
+    expect(m.volatility).not.toBeNull()
+    expect((m.volatility as number) >= 0).toBe(true)
+    expect(m.maxDrawdown).not.toBeNull()
+    // one dip 110 → 105 = ~4.5% is the only drawdown
+    expect(m.maxDrawdown as number).toBeCloseTo((110 - 105) / 110, 10)
+    // sharpe = annualReturn / volatility
+    expect(m.sharpe).toBeCloseTo(
+      (m.annualReturn as number) / (m.volatility as number),
+      8,
+    )
+  })
+
+  it('reports null sharpe for a perfectly flat fund (zero volatility)', () => {
+    const m = computeFundMetrics(days([100, 100, 100, 100]))
+    expect(m.insufficient).toBe(false)
+    expect(m.volatility).toBeCloseTo(0, 12)
+    expect(m.sharpe).toBeNull()
+    expect(m.maxDrawdown).toBe(0)
+  })
+})

--- a/src/lib/funds/metrics.ts
+++ b/src/lib/funds/metrics.ts
@@ -1,0 +1,148 @@
+// Fund performance statistics computed client-side from the
+// GetFundPerformance snapshot series (todoSpec S73–S77). The backend
+// writes one fund_performance_snapshot row daily (total_value_rsd);
+// the FE turns that time series into four risk/return metrics.
+//
+// Assumptions:
+//  - Risk-free rate is 0, so the reward-to-variability (Sharpe) ratio
+//    is simply annualReturn / volatility. Documented here rather than
+//    fetching a policy rate the backend doesn't expose.
+//  - "Periodic" returns are per-snapshot (the cron cadence is daily);
+//    we annualize with PERIODS_PER_YEAR = 252 trading days, falling
+//    back to a span-based annualization for the total return.
+//  - A series with fewer than MIN_SNAPSHOTS points yields `null`
+//    metrics (S74: render "—" / "nedostupno", never garbage).
+
+export const MIN_SNAPSHOTS = 3
+const PERIODS_PER_YEAR = 252
+const MS_PER_YEAR = 365.25 * 24 * 60 * 60 * 1000
+
+export interface FundSnapshotPoint {
+  /** ISO timestamp of the snapshot. */
+  t: string
+  /** total fund value in RSD at that instant. */
+  value: number
+}
+
+export interface FundMetrics {
+  /** Annualized return as a fraction (0.12 = +12%/yr), or null if insufficient/undefined. */
+  annualReturn: number | null
+  /** Annualized stddev of periodic returns as a fraction, or null. */
+  volatility: number | null
+  /** Reward-to-variability (Sharpe, rf=0) = annualReturn / volatility, or null. */
+  sharpe: number | null
+  /** Max peak-to-trough decline as a non-negative fraction (0.2 = -20%), or null. */
+  maxDrawdown: number | null
+  /** True when the series is too short / unusable to compute metrics. */
+  insufficient: boolean
+}
+
+const UNAVAILABLE: FundMetrics = {
+  annualReturn: null,
+  volatility: null,
+  sharpe: null,
+  maxDrawdown: null,
+  insufficient: true,
+}
+
+/**
+ * Normalize a raw snapshot list (in any order, with string values) into
+ * an ascending-by-time numeric series. Drops non-finite / non-positive
+ * values (a 0 value would blow up ratio math and never happens for a
+ * live fund's total value).
+ */
+export function toSeries(
+  rows: ReadonlyArray<{ snapshotAt?: string; totalValueRsd?: string }>,
+): FundSnapshotPoint[] {
+  return rows
+    .map((r) => ({ t: r.snapshotAt ?? '', value: Number(r.totalValueRsd ?? 'NaN') }))
+    .filter((p) => p.t !== '' && Number.isFinite(p.value) && p.value > 0)
+    .sort((a, b) => Date.parse(a.t) - Date.parse(b.t))
+}
+
+/** Simple (arithmetic) returns between consecutive points: r_i = v_i/v_{i-1} - 1. */
+function periodicReturns(values: number[]): number[] {
+  const out: number[] = []
+  for (let i = 1; i < values.length; i++) {
+    out.push(values[i] / values[i - 1] - 1)
+  }
+  return out
+}
+
+/** Population stddev (we treat the snapshot history as the full sample of the period). */
+function stddev(xs: number[]): number {
+  if (xs.length === 0) return 0
+  const mean = xs.reduce((a, b) => a + b, 0) / xs.length
+  const variance = xs.reduce((a, b) => a + (b - mean) ** 2, 0) / xs.length
+  return Math.sqrt(variance)
+}
+
+/**
+ * Max drawdown over the value series, as a non-negative fraction. Walks
+ * the running peak and tracks the deepest decline from any peak.
+ */
+export function maxDrawdown(values: number[]): number {
+  let peak = values[0] ?? 0
+  let worst = 0
+  for (const v of values) {
+    if (v > peak) peak = v
+    if (peak > 0) {
+      const dd = (peak - v) / peak
+      if (dd > worst) worst = dd
+    }
+  }
+  return worst
+}
+
+/**
+ * Annualized total return from first to last point. Uses the actual
+ * elapsed wall-clock span (compounded) so an irregular cron cadence
+ * still annualizes correctly. Returns null when the span is degenerate.
+ */
+export function annualizedReturn(series: FundSnapshotPoint[]): number | null {
+  const first = series[0]
+  const last = series[series.length - 1]
+  if (!first || !last || first.value <= 0) return null
+  const spanMs = Date.parse(last.t) - Date.parse(first.t)
+  if (!Number.isFinite(spanMs) || spanMs <= 0) return null
+  const years = spanMs / MS_PER_YEAR
+  const totalGrowth = last.value / first.value
+  return totalGrowth ** (1 / years) - 1
+}
+
+/** Annualized volatility = stddev(periodic returns) * sqrt(PERIODS_PER_YEAR). */
+export function annualizedVolatility(values: number[]): number {
+  return stddev(periodicReturns(values)) * Math.sqrt(PERIODS_PER_YEAR)
+}
+
+/**
+ * Compute all four fund metrics from a snapshot series. Returns the
+ * UNAVAILABLE sentinel (insufficient=true, all-null) when there are
+ * fewer than MIN_SNAPSHOTS usable points (S74).
+ */
+export function computeFundMetrics(series: FundSnapshotPoint[]): FundMetrics {
+  if (series.length < MIN_SNAPSHOTS) return UNAVAILABLE
+  const values = series.map((p) => p.value)
+
+  const annualReturn = annualizedReturn(series)
+  const volatility = annualizedVolatility(values)
+  // Sharpe is undefined when volatility is ~0 (a perfectly flat fund);
+  // report null rather than Infinity/NaN.
+  const sharpe =
+    annualReturn != null && volatility > 1e-9 ? annualReturn / volatility : null
+
+  return {
+    annualReturn,
+    volatility,
+    sharpe,
+    maxDrawdown: maxDrawdown(values),
+    insufficient: false,
+  }
+}
+
+/** Convenience: compute metrics directly from raw snapshot rows. */
+export function metricsFromSnapshots(
+  rows: ReadonlyArray<{ snapshotAt?: string; totalValueRsd?: string }>,
+): FundMetrics {
+  return computeFundMetrics(toSeries(rows))
+}

--- a/src/lib/funds/useFundMetrics.ts
+++ b/src/lib/funds/useFundMetrics.ts
@@ -1,0 +1,51 @@
+// Batch-fetches each fund's performance snapshot history and computes
+// the four discovery statistics (todoSpec S73–S77) client-side. The
+// GetFundPerformance endpoint already exposes the daily total_value_rsd
+// series, so no backend change is needed — the math lives in
+// `metrics.ts` and is unit-tested there.
+
+import { useQueries } from '@tanstack/react-query'
+import { getFundPerformance } from '@/lib/api/funds'
+import { keys } from '@/lib/query-keys'
+import { metricsFromSnapshots, type FundMetrics } from './metrics'
+
+const UNAVAILABLE: FundMetrics = {
+  annualReturn: null,
+  volatility: null,
+  sharpe: null,
+  maxDrawdown: null,
+  insufficient: true,
+}
+
+export interface FundMetricsLookup {
+  /** Metrics for a fund id; unavailable (insufficient=true) while loading or on error. */
+  get: (fundId: string | undefined) => FundMetrics
+  /** True while any underlying performance query is still fetching. */
+  isFetching: boolean
+}
+
+export function useFundMetrics(
+  fundIds: ReadonlyArray<string | undefined>,
+  days = 365,
+): FundMetricsLookup {
+  const unique = Array.from(new Set(fundIds.filter((id): id is string => Boolean(id))))
+  const results = useQueries({
+    queries: unique.map((id) => ({
+      queryKey: keys.funds.performance(id, days),
+      queryFn: () => getFundPerformance(id, days),
+      // Snapshots roll once a day; keep them warm so the detail page
+      // hit reuses the discovery fetch and vice versa.
+      staleTime: 5 * 60_000,
+    })),
+  })
+
+  const byId = new Map<string, FundMetrics>()
+  results.forEach((r, i) => {
+    byId.set(unique[i], r.data ? metricsFromSnapshots(r.data.snapshots ?? []) : UNAVAILABLE)
+  })
+
+  return {
+    get: (fundId) => (fundId ? (byId.get(fundId) ?? UNAVAILABLE) : UNAVAILABLE),
+    isFetching: results.some((r) => r.isFetching),
+  }
+}


### PR DESCRIPTION
Frontend-only fund statistics. Discovery page gains 4 sortable columns (annual return, reward-to-variability/Sharpe, max drawdown, volatility) computed client-side from the existing `/funds/{id}/performance` snapshot series; metrics show "—" with <3 snapshots (S74). Detail chart overlays an average-of-all-funds comparison line (S75). Pure metric utils with vitest (16 tests).

Scenarios: S73–S77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)