### PR TITLE
feat(trading): order history fields + filters — frontend (S30-S34)

### DIFF
--- a/src/lib/api/generated/models/v1Order.ts
+++ b/src/lib/api/generated/models/v1Order.ts
@@ -41,5 +41,14 @@ export type v1Order = {
      */
     actorKind?: bankaTradingV1UserKind;
     onBehalfOfFundId?: string;
+    /**
+     * todoSpec S30/S31 — per-order execution aggregates over settled
+     * fills: quantity-weighted average execution price, summed paid
+     * commission, and the most recent execution timestamp. Empty/unset
+     * on an order with no settled fills yet.
+     */
+    avgExecutionPrice?: string;
+    totalCommission?: string;
+    lastExecutionAt?: string;
 };
 

--- a/src/lib/api/orders.ts
+++ b/src/lib/api/orders.ts
@@ -16,6 +16,12 @@ export interface ListOrdersArgs {
   // clients/agents (server forces own).
   userId?: string
   securityId?: string
+  // todoSpec S34 — "market" | "limit" | "stop" | "stop_limit".
+  orderType?: string
+  // todoSpec S33 — inclusive creation-date range. RFC3339 timestamps
+  // (pin midnight UTC for a bare YYYY-MM-DD; see makeDateBound below).
+  from?: string
+  to?: string
   page?: number
   pageSize?: number
 }
@@ -23,6 +29,15 @@ export interface ListOrdersArgs {
 export async function listOrders(args: ListOrdersArgs = {}): Promise<v1ListOrdersResponse> {
   const { data } = await api.get<v1ListOrdersResponse>('/v1/orders', { params: args })
   return data
+}
+
+// makeDateBound converts a bare YYYY-MM-DD from <input type="date"> into
+// an RFC3339 timestamp grpc-gateway accepts for a google.protobuf.Timestamp
+// query param (a bare date rejects as "invalid Timestamp"). `end=true`
+// pins the inclusive end-of-day so a `to` bound includes that whole day.
+export function makeDateBound(value: string, end = false): string | undefined {
+  if (!value) return undefined
+  return end ? `${value}T23:59:59Z` : `${value}T00:00:00Z`
 }
 
 export async function getOrder(id: string): Promise<v1Order> {

--- a/src/routes/_authed/banking/trgovina/nalozi/$orderId.tsx
+++ b/src/routes/_authed/banking/trgovina/nalozi/$orderId.tsx
@@ -94,10 +94,22 @@ function OrderDetail() {
 
           <Card>
             <CardHeader><CardTitle>Realizacije</CardTitle></CardHeader>
-            <CardContent>
-              <p className="text-sm text-muted-foreground">
-                Pojedinačne realizacije nisu dostupne za prikaz.
-              </p>
+            <CardContent className="space-y-2 text-sm">
+              {o.lastExecutionAt ? (
+                <>
+                  <Row label="Prosečna izvršna cena">
+                    <span data-cy="order-exec-price">{formatMoney(o.avgExecutionPrice)}</span>
+                  </Row>
+                  <Row label="Plaćena provizija">
+                    <span data-cy="order-commission">{formatMoney(o.totalCommission)}</span>
+                  </Row>
+                  <Row label="Datum izvršenja">
+                    <span data-cy="order-exec-date">{formatDateTime(o.lastExecutionAt)}</span>
+                  </Row>
+                </>
+              ) : (
+                <p className="text-muted-foreground">Nalog još nije realizovan.</p>
+              )}
             </CardContent>
           </Card>
         </>

--- a/src/routes/_authed/banking/trgovina/nalozi/index.tsx
+++ b/src/routes/_authed/banking/trgovina/nalozi/index.tsx
@@ -1,17 +1,19 @@
 import { createFileRoute, Link, redirect, useNavigate } from '@tanstack/react-router'
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { listOrders } from '@/lib/api/orders'
+import { listOrders, makeDateBound, type ListOrdersArgs } from '@/lib/api/orders'
 import { useSecurityTickers } from '@/lib/trading/useSecurityTickers'
 import { keys } from '@/lib/query-keys'
 import { useAuthStore } from '@/lib/auth/store'
 import { Permissions, has } from '@/lib/permissions'
 import { v1OrderStatus } from '@/lib/api/generated/models/v1OrderStatus'
 import { v1Direction } from '@/lib/api/generated/models/v1Direction'
+import { v1OrderType } from '@/lib/api/generated/models/v1OrderType'
 import { directionLabel, orderStatusLabel, orderTypeLabel } from '@/lib/labels'
-import { formatDateTime } from '@/lib/format'
+import { formatDateTime, formatMoney } from '@/lib/format'
 import { Table, THead, TBody, TR, TH, TD, EmptyRow } from '@/components/ui/table'
 import { Select } from '@/components/ui/select'
+import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
 
@@ -29,13 +31,25 @@ function NaloziList() {
   const navigate = useNavigate()
   const [status, setStatus] = useState<string>('')
   const [direction, setDirection] = useState<string>('')
+  const [orderType, setOrderType] = useState<string>('')
+  const [from, setFrom] = useState<string>('')
+  const [to, setTo] = useState<string>('')
 
   // The backend infers user automatically from JWT for client/agent
-  // callers; passing userId is supervisor-only. Direction filter is
-  // applied client-side because backend listOrders doesn't expose it.
+  // callers; passing userId is supervisor-only. Status (S32), type
+  // (S34) and creation-date range (S33) filter server-side; direction
+  // is applied client-side because backend listOrders doesn't expose it.
+  const args: ListOrdersArgs = {}
+  if (status) args.status = status
+  if (orderType) args.orderType = orderType
+  const fromBound = makeDateBound(from)
+  const toBound = makeDateBound(to, true)
+  if (fromBound) args.from = fromBound
+  if (toBound) args.to = toBound
+
   const orders = useQuery({
-    queryKey: keys.order.mine({ status, direction }),
-    queryFn: () => listOrders(status ? { status } : {}),
+    queryKey: keys.order.mine({ status, direction, orderType, from, to }),
+    queryFn: () => listOrders(args),
     refetchInterval: 5_000,
     staleTime: 0,
   })
@@ -77,6 +91,24 @@ function NaloziList() {
             <option value={v1Direction.DIRECTION_SELL}>Prodaja</option>
           </Select>
         </div>
+        <div>
+          <Label>Tip</Label>
+          <Select value={orderType} onChange={(e) => setOrderType(e.target.value)} data-cy="filter-type">
+            <option value="">Svi</option>
+            <option value="market">{orderTypeLabel[v1OrderType.ORDER_TYPE_MARKET]}</option>
+            <option value="limit">{orderTypeLabel[v1OrderType.ORDER_TYPE_LIMIT]}</option>
+            <option value="stop">{orderTypeLabel[v1OrderType.ORDER_TYPE_STOP]}</option>
+            <option value="stop_limit">{orderTypeLabel[v1OrderType.ORDER_TYPE_STOP_LIMIT]}</option>
+          </Select>
+        </div>
+        <div>
+          <Label htmlFor="filter-from">Od datuma</Label>
+          <Input id="filter-from" type="date" value={from} onChange={(e) => setFrom(e.target.value)} data-cy="filter-from" />
+        </div>
+        <div>
+          <Label htmlFor="filter-to">Do datuma</Label>
+          <Input id="filter-to" type="date" value={to} onChange={(e) => setTo(e.target.value)} data-cy="filter-to" />
+        </div>
       </div>
 
       <Table>
@@ -88,12 +120,15 @@ function NaloziList() {
             <TH>Tip</TH>
             <TH className="text-right">Količina</TH>
             <TH className="text-right">Preostalo</TH>
+            <TH className="text-right">Izvršna cena</TH>
+            <TH className="text-right">Provizija</TH>
+            <TH>Datum izvršenja</TH>
             <TH>Status</TH>
           </TR>
         </THead>
         <TBody>
           {items.length === 0 ? (
-            <EmptyRow colSpan={7}>{orders.isFetching ? 'Učitavanje…' : 'Nemate naloga'}</EmptyRow>
+            <EmptyRow colSpan={10}>{orders.isFetching ? 'Učitavanje…' : 'Nemate naloga'}</EmptyRow>
           ) : (
             items.map((o) => (
               <TR
@@ -108,6 +143,15 @@ function NaloziList() {
                 <TD>{o.orderType ? orderTypeLabel[o.orderType] : '—'}</TD>
                 <TD className="text-right">{o.quantity ?? '—'}</TD>
                 <TD className="text-right">{o.remainingQuantity ?? o.quantity ?? '—'}</TD>
+                <TD className="text-right" data-cy="order-row-exec-price">
+                  {o.avgExecutionPrice ? formatMoney(o.avgExecutionPrice) : '—'}
+                </TD>
+                <TD className="text-right" data-cy="order-row-commission">
+                  {o.totalCommission ? formatMoney(o.totalCommission) : '—'}
+                </TD>
+                <TD data-cy="order-row-exec-date">
+                  {o.lastExecutionAt ? formatDateTime(o.lastExecutionAt) : '—'}
+                </TD>
                 <TD><StatusBadge order={o} /></TD>
               </TR>
             ))

--- a/src/routes/_authed/portal/trgovina/nalozi/$orderId.tsx
+++ b/src/routes/_authed/portal/trgovina/nalozi/$orderId.tsx
@@ -160,6 +160,15 @@ function PortalOrderDetail() {
               <Row label="Cena po jedinici">{formatMoney(o.pricePerUnit)}</Row>
               <Row label="Limit">{formatMoney(o.limitPrice)}</Row>
               <Row label="Stop">{formatMoney(o.stopPrice)}</Row>
+              <Row label="Prosečna izvršna cena">
+                <span data-cy="order-exec-price">{o.lastExecutionAt ? formatMoney(o.avgExecutionPrice) : '—'}</span>
+              </Row>
+              <Row label="Plaćena provizija">
+                <span data-cy="order-commission">{o.lastExecutionAt ? formatMoney(o.totalCommission) : '—'}</span>
+              </Row>
+              <Row label="Datum izvršenja">
+                <span data-cy="order-exec-date">{o.lastExecutionAt ? formatDateTime(o.lastExecutionAt) : '—'}</span>
+              </Row>
               <Row label="AON">{o.allOrNone ? 'Da' : 'Ne'}</Row>
               <Row label="Margin">{o.margin ? 'Da' : 'Ne'}</Row>
               <Row label="Status">{o.status ? orderStatusLabel[o.status] : '—'}{o.cancelled ? ' (otkazan)' : ''}{o.isDone ? ' (realizovan)' : ''}</Row>

--- a/src/routes/_authed/portal/trgovina/nalozi/index.tsx
+++ b/src/routes/_authed/portal/trgovina/nalozi/index.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, Link, redirect, useNavigate, useSearch } from '@tansta
 import { useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { z } from 'zod'
-import { listOrders, approveOrder, declineOrder, cancelOrder } from '@/lib/api/orders'
+import { listOrders, approveOrder, declineOrder, cancelOrder, makeDateBound } from '@/lib/api/orders'
 import { apiError } from '@/lib/api/error'
 import { useSecurityTickers } from '@/lib/trading/useSecurityTickers'
 import { isSettlementPast } from '@/lib/trading/settlement'
@@ -12,11 +12,13 @@ import { useAuthStore } from '@/lib/auth/store'
 import { Permissions, hasAny } from '@/lib/permissions'
 import { v1OrderStatus } from '@/lib/api/generated/models/v1OrderStatus'
 import { v1Direction } from '@/lib/api/generated/models/v1Direction'
+import { v1OrderType } from '@/lib/api/generated/models/v1OrderType'
 import { bankaTradingV1UserKind } from '@/lib/api/generated/models/bankaTradingV1UserKind'
 import { directionLabel, orderStatusLabel, orderTypeLabel } from '@/lib/labels'
-import { formatDateTime } from '@/lib/format'
+import { formatDateTime, formatMoney } from '@/lib/format'
 import { Table, THead, TBody, TR, TH, TD, EmptyRow } from '@/components/ui/table'
 import { Select } from '@/components/ui/select'
+import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -55,13 +57,22 @@ function PortalNaloziList() {
 
   const [status, setStatus] = useState<string>(search.status ?? '')
   const [direction, setDirection] = useState<string>('')
+  const [orderType, setOrderType] = useState<string>('')
+  const [from, setFrom] = useState<string>('')
+  const [to, setTo] = useState<string>('')
   const [userId, setUserId] = useState<string>(search.userId ?? '')
   const [actor, setActor] = useState<string>('')
 
   // Backend infers user from JWT for non-supervisor callers; passing
-  // userId silently drops there. Same for userKind.
+  // userId silently drops there. Same for userKind. Status (S32), type
+  // (S34) and creation-date range (S33) all filter server-side.
   const args: Parameters<typeof listOrders>[0] = {}
   if (status) args.status = status
+  if (orderType) args.orderType = orderType
+  const fromBound = makeDateBound(from)
+  const toBound = makeDateBound(to, true)
+  if (fromBound) args.from = fromBound
+  if (toBound) args.to = toBound
   if (canSeeAll) {
     if (userId) args.userId = userId
     if (actor === 'client') args.userKind = bankaTradingV1UserKind.USER_KIND_CLIENT
@@ -131,6 +142,24 @@ function PortalNaloziList() {
             <option value={v1Direction.DIRECTION_SELL}>Prodaja</option>
           </Select>
         </div>
+        <div>
+          <Label>Tip</Label>
+          <Select value={orderType} onChange={(e) => setOrderType(e.target.value)} data-cy="filter-type">
+            <option value="">Svi</option>
+            <option value="market">{orderTypeLabel[v1OrderType.ORDER_TYPE_MARKET]}</option>
+            <option value="limit">{orderTypeLabel[v1OrderType.ORDER_TYPE_LIMIT]}</option>
+            <option value="stop">{orderTypeLabel[v1OrderType.ORDER_TYPE_STOP]}</option>
+            <option value="stop_limit">{orderTypeLabel[v1OrderType.ORDER_TYPE_STOP_LIMIT]}</option>
+          </Select>
+        </div>
+        <div>
+          <Label htmlFor="filter-from">Od datuma</Label>
+          <Input id="filter-from" type="date" value={from} onChange={(e) => setFrom(e.target.value)} data-cy="filter-from" />
+        </div>
+        <div>
+          <Label htmlFor="filter-to">Do datuma</Label>
+          <Input id="filter-to" type="date" value={to} onChange={(e) => setTo(e.target.value)} data-cy="filter-to" />
+        </div>
         {canSeeAll && (
           <>
             <ActuaryPicker
@@ -161,6 +190,9 @@ function PortalNaloziList() {
             <TH className="text-right">Količina</TH>
             <TH className="text-right">Veličina ugovora</TH>
             <TH className="text-right">Cena/jed.</TH>
+            <TH className="text-right">Izvršna cena</TH>
+            <TH className="text-right">Provizija</TH>
+            <TH>Datum izvršenja</TH>
             <TH>Smer</TH>
             <TH className="text-right">Preostalo</TH>
             <TH>Status</TH>
@@ -169,7 +201,7 @@ function PortalNaloziList() {
         </THead>
         <TBody>
           {items.length === 0 ? (
-            <EmptyRow colSpan={11}>{orders.isFetching ? 'Učitavanje…' : 'Nema naloga'}</EmptyRow>
+            <EmptyRow colSpan={14}>{orders.isFetching ? 'Učitavanje…' : 'Nema naloga'}</EmptyRow>
           ) : (
             items.map((o) => (
               <RowActions
@@ -209,6 +241,9 @@ function RowActions({
     remainingQuantity?: number
     contractSize?: string
     pricePerUnit?: string
+    avgExecutionPrice?: string
+    totalCommission?: string
+    lastExecutionAt?: string
     status?: v1OrderStatus
     isDone?: boolean
     cancelled?: boolean
@@ -260,6 +295,15 @@ function RowActions({
         <TD className="text-right">{order.quantity ?? '—'}</TD>
         <TD className="text-right" data-cy="order-row-contract-size">{order.contractSize ?? '—'}</TD>
         <TD className="text-right" data-cy="order-row-ppu">{order.pricePerUnit ?? '—'}</TD>
+        <TD className="text-right" data-cy="order-row-exec-price">
+          {order.avgExecutionPrice ? formatMoney(order.avgExecutionPrice) : '—'}
+        </TD>
+        <TD className="text-right" data-cy="order-row-commission">
+          {order.totalCommission ? formatMoney(order.totalCommission) : '—'}
+        </TD>
+        <TD data-cy="order-row-exec-date">
+          {order.lastExecutionAt ? formatDateTime(order.lastExecutionAt) : '—'}
+        </TD>
         <TD>{order.direction ? directionLabel[order.direction] : '—'}</TD>
         <TD className="text-right">{order.remainingQuantity ?? order.quantity ?? '—'}</TD>
         <TD><StatusBadge order={order} /></TD>
@@ -315,7 +359,7 @@ function RowActions({
       </TR>
       {errMsg && (
         <TR>
-          <TD colSpan={11}><ErrorBanner>{errMsg}</ErrorBanner></TD>
+          <TD colSpan={14}><ErrorBanner>{errMsg}</ErrorBanner></TD>
         </TR>
       )}
     </>


### PR DESCRIPTION
Order list/detail (banking + portal) now show execution price, paid commission, execution date; adds date-range + type filters. Pairs with the backend PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)