### PR TITLE
feat(forex-forwards): terminski ugovori page + supervisor spread editor (C3)

### DIFF
--- a/src/lib/api/forex-forwards.ts
+++ b/src/lib/api/forex-forwards.ts
@@ -1,0 +1,52 @@
+// Forex forwards (terminski valutni ugovori, todoSpec C3). The bank fixes
+// today a rate for a future currency conversion. Concluding a forward
+// reserves the RSD obligation + charges a commission, so it's
+// verification-gated (same 6-digit dialog as a payment); quoting,
+// listing, cancelling, and reading/editing the spread factors are not.
+import { api } from './client'
+import { proofHeaders, type VerificationProof } from './verification'
+import type { v1QuoteForexForwardRequest } from './generated/models/v1QuoteForexForwardRequest'
+import type { v1ForexForwardQuote } from './generated/models/v1ForexForwardQuote'
+import type { v1CreateForexForwardRequest } from './generated/models/v1CreateForexForwardRequest'
+import type { v1ForexForward } from './generated/models/v1ForexForward'
+import type { v1ListForexForwardsResponse } from './generated/models/v1ListForexForwardsResponse'
+import type { v1GetForexForwardSpreadsResponse } from './generated/models/v1GetForexForwardSpreadsResponse'
+import type { v1ForexForwardSpread } from './generated/models/v1ForexForwardSpread'
+import type { v1SetForexForwardSpreadRequest } from './generated/models/v1SetForexForwardSpreadRequest'
+
+export type ForexForward = v1ForexForward
+export type ForexForwardQuote = v1ForexForwardQuote
+export type ForexForwardSpread = v1ForexForwardSpread
+
+export async function quoteForexForward(req: v1QuoteForexForwardRequest): Promise<ForexForwardQuote> {
+  const { data } = await api.post<ForexForwardQuote>('/v1/forex-forwards/quote', req)
+  return data
+}
+
+export async function createForexForward(
+  input: v1CreateForexForwardRequest,
+  proof: VerificationProof,
+): Promise<ForexForward> {
+  const { data } = await api.post<ForexForward>('/v1/forex-forwards', input, { headers: proofHeaders(proof) })
+  return data
+}
+
+export async function listForexForwards(): Promise<v1ListForexForwardsResponse> {
+  const { data } = await api.get<v1ListForexForwardsResponse>('/v1/forex-forwards')
+  return data
+}
+
+export async function cancelForexForward(id: string): Promise<ForexForward> {
+  const { data } = await api.delete<ForexForward>(`/v1/forex-forwards/${id}`)
+  return data
+}
+
+export async function getForexForwardSpreads(): Promise<v1GetForexForwardSpreadsResponse> {
+  const { data } = await api.get<v1GetForexForwardSpreadsResponse>('/v1/forex-forwards/spreads')
+  return data
+}
+
+export async function setForexForwardSpread(input: v1SetForexForwardSpreadRequest): Promise<ForexForwardSpread> {
+  const { data } = await api.put<ForexForwardSpread>('/v1/forex-forwards/spreads', input)
+  return data
+}

--- a/src/lib/api/generated/index.ts
+++ b/src/lib/api/generated/index.ts
@@ -198,6 +198,15 @@ export type { v1RunVariableRateJobResponse } from './models/v1RunVariableRateJob
 export type { v1SchedulePaymentRequest } from './models/v1SchedulePaymentRequest';
 export type { v1ScheduledPayment } from './models/v1ScheduledPayment';
 export { v1ScheduledPaymentStatus } from './models/v1ScheduledPaymentStatus';
+export type { v1CreateForexForwardRequest } from './models/v1CreateForexForwardRequest';
+export type { v1ForexForward } from './models/v1ForexForward';
+export type { v1ForexForwardQuote } from './models/v1ForexForwardQuote';
+export type { v1ForexForwardSpread } from './models/v1ForexForwardSpread';
+export { v1ForexForwardStatus } from './models/v1ForexForwardStatus';
+export type { v1GetForexForwardSpreadsResponse } from './models/v1GetForexForwardSpreadsResponse';
+export type { v1ListForexForwardsResponse } from './models/v1ListForexForwardsResponse';
+export type { v1QuoteForexForwardRequest } from './models/v1QuoteForexForwardRequest';
+export type { v1SetForexForwardSpreadRequest } from './models/v1SetForexForwardSpreadRequest';
 export type { v1Security } from './models/v1Security';
 export { v1SecurityType } from './models/v1SecurityType';
 export type { v1SecurityWithListing } from './models/v1SecurityWithListing';

--- a/src/lib/api/generated/models/v1CreateForexForwardRequest.ts
+++ b/src/lib/api/generated/models/v1CreateForexForwardRequest.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { bankaBankV1Currency } from './bankaBankV1Currency';
+export type v1CreateForexForwardRequest = {
+    baseCurrency?: bankaBankV1Currency;
+    notional?: string;
+    settlementDate?: string;
+};

--- a/src/lib/api/generated/models/v1ForexForward.ts
+++ b/src/lib/api/generated/models/v1ForexForward.ts
@@ -1,0 +1,26 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { bankaBankV1Currency } from './bankaBankV1Currency';
+import type { v1ForexForwardStatus } from './v1ForexForwardStatus';
+export type v1ForexForward = {
+    id?: string;
+    clientId?: string;
+    baseCurrency?: bankaBankV1Currency;
+    quoteCurrency?: bankaBankV1Currency;
+    notional?: string;
+    forwardRate?: string;
+    spotAskRate?: string;
+    spreadFactor?: string;
+    daysToSettlement?: number;
+    commission?: string;
+    reservationId?: string;
+    fromAccountId?: string;
+    toAccountId?: string;
+    settlementDate?: string;
+    status?: v1ForexForwardStatus;
+    failureReason?: string;
+    createdAt?: string;
+    settledAt?: string;
+};

--- a/src/lib/api/generated/models/v1ForexForwardQuote.ts
+++ b/src/lib/api/generated/models/v1ForexForwardQuote.ts
@@ -1,0 +1,16 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { bankaBankV1Currency } from './bankaBankV1Currency';
+export type v1ForexForwardQuote = {
+    baseCurrency?: bankaBankV1Currency;
+    quoteCurrency?: bankaBankV1Currency;
+    notional?: string;
+    spotAskRate?: string;
+    spreadFactor?: string;
+    daysToSettlement?: number;
+    forwardRate?: string;
+    quoteAmount?: string;
+    commission?: string;
+};

--- a/src/lib/api/generated/models/v1ForexForwardSpread.ts
+++ b/src/lib/api/generated/models/v1ForexForwardSpread.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { bankaBankV1Currency } from './bankaBankV1Currency';
+export type v1ForexForwardSpread = {
+    baseCurrency?: bankaBankV1Currency;
+    quoteCurrency?: bankaBankV1Currency;
+    spreadFactor?: string;
+    updatedBy?: string;
+    updatedAt?: string;
+};

--- a/src/lib/api/generated/models/v1ForexForwardStatus.ts
+++ b/src/lib/api/generated/models/v1ForexForwardStatus.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export enum v1ForexForwardStatus {
+    FOREX_FORWARD_STATUS_UNSPECIFIED = 'FOREX_FORWARD_STATUS_UNSPECIFIED',
+    FOREX_FORWARD_STATUS_ACTIVE = 'FOREX_FORWARD_STATUS_ACTIVE',
+    FOREX_FORWARD_STATUS_SETTLED = 'FOREX_FORWARD_STATUS_SETTLED',
+    FOREX_FORWARD_STATUS_CANCELLED = 'FOREX_FORWARD_STATUS_CANCELLED',
+    FOREX_FORWARD_STATUS_FAILED = 'FOREX_FORWARD_STATUS_FAILED',
+}

--- a/src/lib/api/generated/models/v1GetForexForwardSpreadsResponse.ts
+++ b/src/lib/api/generated/models/v1GetForexForwardSpreadsResponse.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { v1ForexForwardSpread } from './v1ForexForwardSpread';
+export type v1GetForexForwardSpreadsResponse = {
+    spreads?: Array<v1ForexForwardSpread>;
+};

--- a/src/lib/api/generated/models/v1ListForexForwardsResponse.ts
+++ b/src/lib/api/generated/models/v1ListForexForwardsResponse.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { v1ForexForward } from './v1ForexForward';
+export type v1ListForexForwardsResponse = {
+    forexForwards?: Array<v1ForexForward>;
+};

--- a/src/lib/api/generated/models/v1QuoteForexForwardRequest.ts
+++ b/src/lib/api/generated/models/v1QuoteForexForwardRequest.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { bankaBankV1Currency } from './bankaBankV1Currency';
+export type v1QuoteForexForwardRequest = {
+    baseCurrency?: bankaBankV1Currency;
+    notional?: string;
+    settlementDate?: string;
+};

--- a/src/lib/api/generated/models/v1SetForexForwardSpreadRequest.ts
+++ b/src/lib/api/generated/models/v1SetForexForwardSpreadRequest.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { bankaBankV1Currency } from './bankaBankV1Currency';
+export type v1SetForexForwardSpreadRequest = {
+    baseCurrency?: bankaBankV1Currency;
+    quoteCurrency?: bankaBankV1Currency;
+    spreadFactor?: string;
+};

--- a/src/lib/labels.test.ts
+++ b/src/lib/labels.test.ts
@@ -14,6 +14,7 @@ import {
   txKindLabel,
   txStatusLabel,
   scheduledPaymentStatusLabel,
+  forexForwardStatusLabel,
   subtypesForKind,
   orderTypeLabel,
   orderStatusLabel,
@@ -23,6 +24,7 @@ import {
   actuaryTypeLabel,
 } from './labels'
 import { v1AccountKind } from './api/generated/models/v1AccountKind'
+import { v1ForexForwardStatus } from './api/generated/models/v1ForexForwardStatus'
 import { v1AccountSubtype } from './api/generated/models/v1AccountSubtype'
 import { v1AccountStatus } from './api/generated/models/v1AccountStatus'
 import { v1CardBrand } from './api/generated/models/v1CardBrand'
@@ -74,6 +76,8 @@ describe('label tables are complete for every enum value', () => {
   it('txStatusLabel', () => expectComplete('txStatusLabel', v1TransactionStatus, txStatusLabel))
   it('scheduledPaymentStatusLabel', () =>
     expectComplete('scheduledPaymentStatusLabel', v1ScheduledPaymentStatus, scheduledPaymentStatusLabel))
+  it('forexForwardStatusLabel', () =>
+    expectComplete('forexForwardStatusLabel', v1ForexForwardStatus, forexForwardStatusLabel))
   it('orderTypeLabel', () => expectComplete('orderTypeLabel', v1OrderType, orderTypeLabel))
   it('orderStatusLabel', () => expectComplete('orderStatusLabel', v1OrderStatus, orderStatusLabel))
   it('directionLabel', () => expectComplete('directionLabel', v1Direction, directionLabel))

--- a/src/lib/labels.ts
+++ b/src/lib/labels.ts
@@ -15,6 +15,7 @@ import { v1EmploymentStatus } from './api/generated/models/v1EmploymentStatus'
 import { v1TransactionKind } from './api/generated/models/v1TransactionKind'
 import { v1TransactionStatus } from './api/generated/models/v1TransactionStatus'
 import { v1ScheduledPaymentStatus } from './api/generated/models/v1ScheduledPaymentStatus'
+import { v1ForexForwardStatus } from './api/generated/models/v1ForexForwardStatus'
 import { v1OrderType } from './api/generated/models/v1OrderType'
 import { v1OrderStatus } from './api/generated/models/v1OrderStatus'
 import { v1Direction } from './api/generated/models/v1Direction'
@@ -173,6 +174,14 @@ export const scheduledPaymentStatusLabel: Record<v1ScheduledPaymentStatus, strin
   [v1ScheduledPaymentStatus.SCHEDULED_PAYMENT_STATUS_COMPLETED]: 'Realizovano',
   [v1ScheduledPaymentStatus.SCHEDULED_PAYMENT_STATUS_FAILED]: 'Neuspešno',
   [v1ScheduledPaymentStatus.SCHEDULED_PAYMENT_STATUS_CANCELLED]: 'Otkazano',
+}
+
+export const forexForwardStatusLabel: Record<v1ForexForwardStatus, string> = {
+  [v1ForexForwardStatus.FOREX_FORWARD_STATUS_UNSPECIFIED]: '—',
+  [v1ForexForwardStatus.FOREX_FORWARD_STATUS_ACTIVE]: 'Aktivan',
+  [v1ForexForwardStatus.FOREX_FORWARD_STATUS_SETTLED]: 'Poravnan',
+  [v1ForexForwardStatus.FOREX_FORWARD_STATUS_CANCELLED]: 'Otkazan',
+  [v1ForexForwardStatus.FOREX_FORWARD_STATUS_FAILED]: 'Neuspešan',
 }
 
 export const orderTypeLabel: Record<v1OrderType, string> = {

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -49,6 +49,12 @@ export const keys = {
     all: ['scheduledPayment'] as const,
     list: () => ['scheduledPayment', 'list'] as const,
   },
+  forexForward: {
+    all: ['forexForward'] as const,
+    list: () => ['forexForward', 'list'] as const,
+    quote: (args: object) => ['forexForward', 'quote', args] as const,
+    spreads: () => ['forexForward', 'spreads'] as const,
+  },
   loan: {
     all: ['loan'] as const,
     list: (args: object) => ['loan', 'list', args] as const,

--- a/src/routes/_authed/banking.tsx
+++ b/src/routes/_authed/banking.tsx
@@ -25,6 +25,7 @@ function BankingLayout() {
     { to: '/banking/placanja', label: 'Plaćanja' },
     { to: '/banking/transferi', label: 'Transferi' },
     { to: '/banking/menjacnica', label: 'Menjačnica' },
+    { to: '/banking/terminski', label: '↳ Terminski ugovori' },
     { to: '/banking/primaoci', label: 'Primaoci' },
     { to: '/banking/krediti', label: 'Krediti' },
     { to: '/banking/portfolio', label: 'Portfolio', hidden: !has(perms, Permissions.TradingClient) },

--- a/src/routes/_authed/banking/terminski.tsx
+++ b/src/routes/_authed/banking/terminski.tsx
@@ -1,0 +1,266 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useState } from 'react'
+import {
+  quoteForexForward,
+  createForexForward,
+  listForexForwards,
+  cancelForexForward,
+} from '@/lib/api/forex-forwards'
+import { apiError } from '@/lib/api/error'
+import type { VerificationProof } from '@/lib/api/verification'
+import { keys } from '@/lib/query-keys'
+import { formatMoney, formatRate, currencyLabel, formatDate } from '@/lib/format'
+import { forexForwardStatusLabel } from '@/lib/labels'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select } from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+import { ErrorBanner } from '@/components/ui/error'
+import { Card } from '@/components/ui/card'
+import { Table, THead, TBody, TR, TH, TD } from '@/components/ui/table'
+import { VerificationDialog } from '@/components/verification/verification-dialog'
+import { bankaBankV1Currency } from '@/lib/api/generated/models/bankaBankV1Currency'
+import { v1ForexForwardStatus } from '@/lib/api/generated/models/v1ForexForwardStatus'
+import type { v1CreateForexForwardRequest } from '@/lib/api/generated/models/v1CreateForexForwardRequest'
+
+export const Route = createFileRoute('/_authed/banking/terminski')({
+  component: TerminskiUgovori,
+})
+
+// Forward base currencies — everything except RSD (the settlement leg).
+const baseCurrencies = [
+  bankaBankV1Currency.CURRENCY_EUR,
+  bankaBankV1Currency.CURRENCY_CHF,
+  bankaBankV1Currency.CURRENCY_USD,
+  bankaBankV1Currency.CURRENCY_GBP,
+  bankaBankV1Currency.CURRENCY_JPY,
+  bankaBankV1Currency.CURRENCY_CAD,
+  bankaBankV1Currency.CURRENCY_AUD,
+]
+
+const schema = z.object({
+  baseCurrency: z.string().min(1, 'Izaberite valutu'),
+  notional: z.string().regex(/^[0-9]+(\.[0-9]{1,2})?$/, 'Iznos mora biti broj'),
+  settlementDate: z.string().min(1, 'Izaberite datum'),
+})
+
+type FormValues = z.infer<typeof schema>
+
+// <input type="date"> yields a bare YYYY-MM-DD; grpc-gateway needs a full
+// RFC3339 timestamp or it rejects "invalid google.protobuf.Timestamp".
+// Pin midnight UTC. See [[yyyymmdd-proto-timestamp]].
+function toTimestamp(date: string): string {
+  return `${date}T00:00:00Z`
+}
+
+function TerminskiUgovori() {
+  const navigate = useNavigate()
+  const qc = useQueryClient()
+  const [pending, setPending] = useState<v1CreateForexForwardRequest | null>(null)
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { baseCurrency: '', notional: '', settlementDate: '' },
+  })
+
+  const base = form.watch('baseCurrency')
+  const notional = form.watch('notional')
+  const settlementDate = form.watch('settlementDate')
+
+  const quote = useQuery({
+    queryKey: keys.forexForward.quote({ base, notional, settlementDate }),
+    queryFn: () =>
+      quoteForexForward({
+        baseCurrency: base as bankaBankV1Currency,
+        notional,
+        settlementDate: toTimestamp(settlementDate),
+      }),
+    enabled:
+      !!base &&
+      /^[0-9]+(\.[0-9]{1,2})?$/.test(notional) &&
+      Number(notional) > 0 &&
+      !!settlementDate &&
+      new Date(toTimestamp(settlementDate)) > new Date(),
+  })
+
+  const forwards = useQuery({
+    queryKey: keys.forexForward.list(),
+    queryFn: () => listForexForwards(),
+  })
+
+  const conclude = useMutation({
+    mutationFn: ({ payload, proof }: { payload: v1CreateForexForwardRequest; proof: VerificationProof }) =>
+      createForexForward(payload, proof),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: keys.forexForward.all })
+      qc.invalidateQueries({ queryKey: keys.account.all })
+      form.reset()
+    },
+  })
+
+  const cancel = useMutation({
+    mutationFn: (id: string) => cancelForexForward(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: keys.forexForward.all })
+      qc.invalidateQueries({ queryKey: keys.account.all })
+    },
+  })
+
+  const errMsg = conclude.error
+    ? apiError(conclude.error, 'Greška pri zaključivanju terminskog ugovora.')
+    : quote.error
+      ? apiError(quote.error, 'Ponuda nije dostupna za izabrane parametre.')
+      : null
+
+  function onSubmit(v: FormValues) {
+    setPending({
+      baseCurrency: v.baseCurrency as bankaBankV1Currency,
+      notional: v.notional,
+      settlementDate: toTimestamp(v.settlementDate),
+    })
+  }
+
+  return (
+    <main className="container max-w-3xl space-y-6 py-8">
+      <h1 className="text-2xl font-semibold">Terminski valutni ugovori</h1>
+      <p className="text-sm text-muted-foreground">
+        Fiksirajte danas kurs za buduću konverziju valuta. Na datum poravnanja banka tereti vaš RSD
+        račun i pripisuje ugovoreni iznos na devizni račun po unapred utvrđenom kursu.
+      </p>
+
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="space-y-4 rounded-lg border border-border bg-surface p-6"
+        aria-label="Nov terminski ugovor"
+      >
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <Label>Valuta</Label>
+            <Select {...form.register('baseCurrency')}>
+              <option value="">— izaberite —</option>
+              {baseCurrencies.map((c) => (
+                <option key={c} value={c}>
+                  {currencyLabel(c)}
+                </option>
+              ))}
+            </Select>
+            {form.formState.errors.baseCurrency && (
+              <div className="mt-1 text-xs text-danger">{form.formState.errors.baseCurrency.message}</div>
+            )}
+          </div>
+          <div>
+            <Label>Datum poravnanja</Label>
+            <Input type="date" {...form.register('settlementDate')} />
+            {form.formState.errors.settlementDate && (
+              <div className="mt-1 text-xs text-danger">{form.formState.errors.settlementDate.message}</div>
+            )}
+          </div>
+        </div>
+
+        <div>
+          <Label>Nominalni iznos ({base ? currencyLabel(base) : '—'})</Label>
+          <Input inputMode="decimal" {...form.register('notional')} />
+          {form.formState.errors.notional && (
+            <div className="mt-1 text-xs text-danger">{form.formState.errors.notional.message}</div>
+          )}
+        </div>
+
+        {quote.data && (
+          <div className="rounded-md bg-primary-soft p-4 text-sm text-primary-soft-foreground">
+            <div className="grid grid-cols-2 gap-2">
+              <div>Terminski kurs:</div>
+              <div className="text-right font-mono">{formatRate(quote.data.forwardRate)}</div>
+              <div>Spot kurs (prodajni):</div>
+              <div className="text-right font-mono">{formatRate(quote.data.spotAskRate)}</div>
+              <div>Dana do poravnanja:</div>
+              <div className="text-right">{quote.data.daysToSettlement}</div>
+              <div>Provizija:</div>
+              <div className="text-right">{formatMoney(quote.data.commission, 'RSD')}</div>
+              <div className="font-medium">Obaveza (rezerviše se):</div>
+              <div className="text-right font-mono font-semibold">
+                {formatMoney(quote.data.quoteAmount, 'RSD')}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {errMsg && <ErrorBanner>{errMsg}</ErrorBanner>}
+
+        <div className="flex justify-end">
+          <Button type="submit" disabled={conclude.isPending || quote.isFetching || !quote.data}>
+            {conclude.isPending ? 'Šaljem…' : 'Zaključi ugovor'}
+          </Button>
+        </div>
+      </form>
+
+      <section>
+        <h2 className="mb-3 text-lg font-semibold">Moji terminski ugovori</h2>
+        {forwards.data?.forexForwards && forwards.data.forexForwards.length > 0 ? (
+          <Table>
+            <THead>
+              <TR>
+                <TH>Valuta</TH>
+                <TH className="text-right">Nominala</TH>
+                <TH className="text-right">Kurs</TH>
+                <TH>Poravnanje</TH>
+                <TH>Status</TH>
+                <TH></TH>
+              </TR>
+            </THead>
+            <TBody>
+              {forwards.data.forexForwards.map((f) => (
+                <TR key={f.id}>
+                  <TD>{currencyLabel(f.baseCurrency!)}</TD>
+                  <TD className="text-right font-mono">
+                    {formatMoney(f.notional, currencyLabel(f.baseCurrency!))}
+                  </TD>
+                  <TD className="text-right font-mono">{formatRate(f.forwardRate)}</TD>
+                  <TD>{formatDate(f.settlementDate)}</TD>
+                  <TD>{forexForwardStatusLabel[f.status ?? v1ForexForwardStatus.FOREX_FORWARD_STATUS_UNSPECIFIED]}</TD>
+                  <TD className="text-right">
+                    {f.status === v1ForexForwardStatus.FOREX_FORWARD_STATUS_ACTIVE && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled={cancel.isPending}
+                        onClick={() => cancel.mutate(f.id!)}
+                      >
+                        Otkaži
+                      </Button>
+                    )}
+                  </TD>
+                </TR>
+              ))}
+            </TBody>
+          </Table>
+        ) : (
+          <Card className="p-6 text-sm text-muted-foreground">Nemate zaključene terminske ugovore.</Card>
+        )}
+        {cancel.error && <ErrorBanner>{apiError(cancel.error, 'Otkazivanje nije uspelo.')}</ErrorBanner>}
+      </section>
+
+      <VerificationDialog
+        open={!!pending}
+        kind="payment"
+        title="Potvrda terminskog ugovora"
+        description="Unesite verifikacioni kod kako biste potvrdili zaključivanje ugovora."
+        onCancel={() => setPending(null)}
+        onConfirm={async (proof) => {
+          if (!pending) return
+          await conclude.mutateAsync({ payload: pending, proof })
+          setPending(null)
+        }}
+      />
+
+      <div className="flex justify-start">
+        <Button variant="ghost" onClick={() => navigate({ to: '/banking/menjacnica' })}>
+          ← Nazad na menjačnicu
+        </Button>
+      </div>
+    </main>
+  )
+}

--- a/src/routes/_authed/portal.tsx
+++ b/src/routes/_authed/portal.tsx
@@ -31,6 +31,11 @@ function PortalLayout() {
     { to: '/portal/loans', label: 'Krediti', hidden: !has(perms, Permissions.LoanRead) },
     { to: '/portal/exchange', label: 'Kursna lista', hidden: !has(perms, Permissions.ExchangeWrite) },
     {
+      to: '/portal/terminski-spreadovi',
+      label: 'Terminski — spread',
+      hidden: !has(perms, Permissions.ActuarySupervisor),
+    },
+    {
       to: '/portal/trgovina',
       label: 'Trgovina',
       hidden: !hasAny(perms, [Permissions.Actuary, Permissions.ActuarySupervisor, Permissions.ActuaryAgent, Permissions.Admin]),

--- a/src/routes/_authed/portal/terminski-spreadovi.tsx
+++ b/src/routes/_authed/portal/terminski-spreadovi.tsx
@@ -1,0 +1,146 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { getForexForwardSpreads, setForexForwardSpread } from '@/lib/api/forex-forwards'
+import { apiError } from '@/lib/api/error'
+import { keys } from '@/lib/query-keys'
+import { currencyLabel, formatDateTime } from '@/lib/format'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select } from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+import { ErrorBanner } from '@/components/ui/error'
+import { Card } from '@/components/ui/card'
+import { Table, THead, TBody, TR, TH, TD } from '@/components/ui/table'
+import { bankaBankV1Currency } from '@/lib/api/generated/models/bankaBankV1Currency'
+
+export const Route = createFileRoute('/_authed/portal/terminski-spreadovi')({
+  component: TerminskiSpreadovi,
+})
+
+const baseCurrencies = [
+  bankaBankV1Currency.CURRENCY_EUR,
+  bankaBankV1Currency.CURRENCY_CHF,
+  bankaBankV1Currency.CURRENCY_USD,
+  bankaBankV1Currency.CURRENCY_GBP,
+  bankaBankV1Currency.CURRENCY_JPY,
+  bankaBankV1Currency.CURRENCY_CAD,
+  bankaBankV1Currency.CURRENCY_AUD,
+]
+
+const schema = z.object({
+  baseCurrency: z.string().min(1, 'Izaberite valutu'),
+  // Annualised spread factor, e.g. 0.02 = 2%/yr.
+  spreadFactor: z.string().regex(/^[0-9]+(\.[0-9]{1,8})?$/, 'Faktor mora biti broj'),
+})
+
+type FormValues = z.infer<typeof schema>
+
+function TerminskiSpreadovi() {
+  const qc = useQueryClient()
+
+  const spreads = useQuery({
+    queryKey: keys.forexForward.spreads(),
+    queryFn: () => getForexForwardSpreads(),
+  })
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { baseCurrency: '', spreadFactor: '' },
+  })
+
+  const save = useMutation({
+    mutationFn: (v: FormValues) =>
+      setForexForwardSpread({
+        baseCurrency: v.baseCurrency as bankaBankV1Currency,
+        quoteCurrency: bankaBankV1Currency.CURRENCY_RSD,
+        spreadFactor: v.spreadFactor,
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: keys.forexForward.spreads() })
+      form.reset()
+    },
+  })
+
+  const errMsg = save.error ? apiError(save.error, 'Čuvanje spread faktora nije uspelo.') : null
+
+  return (
+    <main className="container max-w-3xl space-y-6 py-8">
+      <h1 className="text-2xl font-semibold">Terminski ugovori — spread faktor</h1>
+      <p className="text-sm text-muted-foreground">
+        Godišnji spread faktor po valutnom paru ulazi u formulu terminskog kursa. Veći faktor znači
+        veći terminski kurs za duže ročnosti.
+      </p>
+
+      <form
+        onSubmit={form.handleSubmit((v) => save.mutate(v))}
+        className="space-y-4 rounded-lg border border-border bg-surface p-6"
+        aria-label="Podešavanje spread faktora"
+      >
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <Label>Valuta (× RSD)</Label>
+            <Select {...form.register('baseCurrency')}>
+              <option value="">— izaberite —</option>
+              {baseCurrencies.map((c) => (
+                <option key={c} value={c}>
+                  {currencyLabel(c)} / RSD
+                </option>
+              ))}
+            </Select>
+            {form.formState.errors.baseCurrency && (
+              <div className="mt-1 text-xs text-danger">{form.formState.errors.baseCurrency.message}</div>
+            )}
+          </div>
+          <div>
+            <Label>Spread faktor (npr. 0.02 = 2%/god.)</Label>
+            <Input inputMode="decimal" {...form.register('spreadFactor')} />
+            {form.formState.errors.spreadFactor && (
+              <div className="mt-1 text-xs text-danger">{form.formState.errors.spreadFactor.message}</div>
+            )}
+          </div>
+        </div>
+
+        {errMsg && <ErrorBanner>{errMsg}</ErrorBanner>}
+
+        <div className="flex justify-end">
+          <Button type="submit" disabled={save.isPending}>
+            {save.isPending ? 'Čuvam…' : 'Sačuvaj'}
+          </Button>
+        </div>
+      </form>
+
+      <section>
+        <h2 className="mb-3 text-lg font-semibold">Podešeni parovi</h2>
+        {spreads.data?.spreads && spreads.data.spreads.length > 0 ? (
+          <Table>
+            <THead>
+              <TR>
+                <TH>Par</TH>
+                <TH className="text-right">Spread faktor</TH>
+                <TH>Ažurirano</TH>
+              </TR>
+            </THead>
+            <TBody>
+              {spreads.data.spreads.map((s, i) => (
+                <TR key={i}>
+                  <TD>
+                    {currencyLabel(s.baseCurrency!)} / {currencyLabel(s.quoteCurrency!)}
+                  </TD>
+                  <TD className="text-right font-mono">{s.spreadFactor}</TD>
+                  <TD>{formatDateTime(s.updatedAt)}</TD>
+                </TR>
+              ))}
+            </TBody>
+          </Table>
+        ) : (
+          <Card className="p-6 text-sm text-muted-foreground">
+            Nijedan par nije podešen — koristi se podrazumevani faktor (2%/god.).
+          </Card>
+        )}
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
Client page: quote (ForwardRate/commission preview) → conclude (verification-gated) → list + cancel. Supervisor page: per-pair SpreadFactor editor. Pairs with the backend PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)