### PR TITLE
test(c4): reseed after saga-scenarios suite so it can't poison later runs

### DIFF
--- a/cypress/e2e/celina4/c4-saga-scenarios.cy.ts
+++ b/cypress/e2e/celina4/c4-saga-scenarios.cy.ts
@@ -306,6 +306,20 @@ describe('Celina 4 — SAGA pattern (live scenarios 1-13)', () => {
     cy.resetBackend()
   })
 
+  // Leave the shared backend in the clean seeded state we started from.
+  // S12/S13 deactivate the buyer/seller USD accounts (and the suite leaves
+  // residual OTC threads + reserved holdings from its last test). The
+  // beforeEach resetBackend keeps each test here clean, but nothing
+  // restores state after the final test — so a persistent-backend run
+  // afterwards (e.g. the c4-aggressive soak, which does NOT reset and
+  // assumes a fresh seed) would inherit a dead account + reserved holdings
+  // and every OTC `accept` would 500. This after() hook makes the suite
+  // ordering-independent by reseeding once on the way out. Uses the
+  // resetBackend task directly (no SPA visit needed for teardown).
+  after(() => {
+    cy.task('resetBackend', {}, { timeout: 120000 })
+  })
+
   it('S1 — happy path: full exercise debits buyer, credits seller, transfers shares', () => {
     fixtures().then((f) => {
       activeContract(f).then((contractId) => {


### PR DESCRIPTION
## Problem

`c4-saga-scenarios` (e2e) reseeds in `beforeEach` so each of its tests starts clean, but nothing restores state **after the final test**. Its S12/S13 deactivate the buyer/seller USD accounts, and the suite's last test leaves residual OTC threads + reserved holdings.

A persistent-backend run afterwards inherits that dirty state. Concretely, running the `c4-aggressive` soak (which does **not** reset and assumes a fresh seed) right after `c4-saga-scenarios` failed 5/11: every OTC `accept` 500'd because the seeded account was left `inactive` (`bank.CommitReservedFunds: "jedan od računa nije aktivan"`), plus a stray `CreateOTCOffer FailedPrecondition` from residual reserved holdings. The saga code itself was fine — the logs showed the accept saga correctly compensating the inactive-account failure.

## Fix

Add an `after()` hook to the suite that reseeds once on the way out via the `resetBackend` task (no SPA visit needed for teardown). This makes the suite ordering-independent without touching the soak suite's intentional "build-on-each-other" design.

I picked the e2e side deliberately: the soak specs (`c3-multi-round`, `c4-multi-round`) build on each other's state and assume a fresh seed from the wrapper, so adding a reset inside the soak would break that chain. Cleaning up the contamination *source* is the safe fix.

## Verified live (full stack, merged backend)

- `c4-saga-scenarios`: **11/11** (2 intentional skips) → post-suite DB clean: `0` inactive accounts, `0` OTC offers/contracts, `0` reserved holdings.
- `c4-aggressive` immediately after, **no manual reset**: **11/11** (previously 5/11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)