### PR TITLE
test(cypress): e2e specs for all new todoSpec features (C1–C5)

### DIFF
--- a/cypress/e2e/celina1/audit-log.cy.ts
+++ b/cypress/e2e/celina1/audit-log.cy.ts
@@ -1,0 +1,87 @@
+/// <reference types="cypress" />
+
+// Live-backend c1 spec — audit log (todoSpec S40–S46).
+//
+// A supervisor changing an agent's daily limit emits a `limit.change`
+// audit entry (services/trading/internal/service/actuaries.go: the
+// UpdateActuaryLimit path records action="limit.change" against the
+// agent, with old→new daily limit). The audit-log page
+// (/portal/audit-log) renders who/when + old→new and filters by action
+// type + by user. Clients are denied the page (S46).
+//
+// The limit change at /portal/aktuari/$id is NOT verification-gated (the
+// gateway's DefaultRules only gate /accounts/{id}/limits + /cards/{id}/
+// limit), so the supervisor can save it directly — no code dialog here.
+
+const AGENT_EMAIL = 'aktuar@banka.local'
+
+describe('Celina 1 — audit log (live backend)', () => {
+  beforeEach(() => {
+    cy.resetBackend()
+    cy.resetAgentLimit()
+  })
+
+  it('supervizor menja limit agentu → zapis se vidi u audit logu (S40–S43)', () => {
+    // ---- Phase 1: supervisor opens the agent + changes the daily limit.
+    cy.loginAsSupervisor()
+    cy.visit('/portal/aktuari')
+    cy.contains('h1', 'Aktuari', { timeout: 15000 }).should('be.visible')
+    // Row click navigates to the detail page (whole <tr> is clickable).
+    cy.contains('tr', AGENT_EMAIL, { timeout: 10000 }).click()
+    cy.url({ timeout: 10000 }).should('match', /\/portal\/aktuari\/[0-9a-f-]+/)
+
+    // Seed default daily_limit is 200000; bump to 250000.
+    cy.get('[data-cy="daily-limit-input"]', { timeout: 10000 }).clear().type('250000')
+    cy.get('[data-cy="save-limit"]').click()
+    // The "Trenutno" hint re-renders with the saved value once the
+    // mutation invalidates the query.
+    cy.contains('Trenutno: 250.000,00 RSD', { timeout: 10000 }).should('be.visible')
+
+    // ---- Phase 2: open the audit log, see the limit-change entry.
+    cy.visit('/portal/audit-log')
+    cy.contains('h1', 'Audit log', { timeout: 15000 }).should('be.visible')
+    cy.contains('tr', 'Promena limita', { timeout: 10000 })
+      .should('be.visible')
+      // old → new: 200000 → 250000 (rendered verbatim from oldValue/newValue).
+      .within(() => {
+        cy.contains('200000').should('exist')
+        cy.contains('250000').should('exist')
+      })
+  })
+
+  it('filter po tipu akcije i po korisniku (S44/S45)', () => {
+    // Produce a limit-change entry first.
+    cy.loginAsSupervisor()
+    cy.visit('/portal/aktuari')
+    cy.contains('tr', AGENT_EMAIL, { timeout: 15000 }).click()
+    cy.url({ timeout: 10000 }).should('match', /\/portal\/aktuari\/[0-9a-f-]+/)
+    cy.get('[data-cy="daily-limit-input"]', { timeout: 10000 }).clear().type('210000')
+    cy.get('[data-cy="save-limit"]').click()
+    cy.contains('Trenutno: 210.000,00 RSD', { timeout: 10000 }).should('be.visible')
+
+    cy.visit('/portal/audit-log')
+    cy.contains('h1', 'Audit log', { timeout: 15000 }).should('be.visible')
+
+    // S44 — filter by action type. The "Tip akcije" <select> uses the
+    // action key as the option value; "Promena limita" → limit.change.
+    cy.contains('label', 'Tip akcije').find('select').select('limit.change')
+    cy.contains('tr', 'Promena limita', { timeout: 10000 }).should('be.visible')
+
+    // S45 — filter by user. The supervisor performed the action; their
+    // display name is the actor. Filtering by their name keeps the row;
+    // a nonsense needle empties the table.
+    cy.contains('label', 'Korisnik').find('input').clear().type('NepostojeciKorisnik123')
+    cy.contains('Nema zapisa.', { timeout: 10000 }).should('be.visible')
+  })
+
+  it('klijentu je zabranjen pristup audit logu (S46)', () => {
+    // The /portal layout redirects clients to /banking before the
+    // audit-log route's own admin/supervisor gate even runs, so a client
+    // visiting /portal/audit-log lands in the banking app, never on the log.
+    cy.loginAsClient()
+    cy.visit('/portal/audit-log')
+    cy.url({ timeout: 10000 }).should('include', '/banking')
+    cy.url().should('not.include', '/audit-log')
+    cy.contains('h1', 'Audit log').should('not.exist')
+  })
+})

--- a/cypress/e2e/celina1/lockout.cy.ts
+++ b/cypress/e2e/celina1/lockout.cy.ts
@@ -1,0 +1,104 @@
+/// <reference types="cypress" />
+
+// Live-backend c1 spec — brute-force login lockout (todoSpec S7–S11).
+//
+// Backend policy (services/user/internal/service/auth.go):
+//   maxFailedLogins = 5, lockoutDuration = 15 min.
+//   - 5 consecutive wrong passwords lock the account; the 5th attempt
+//     returns the "Nalog je zaključan…" message and persists
+//     locked_until + failed_login_attempts on the clients row.
+//   - while locked, even the correct password is refused with the
+//     "Nalog je privremeno zaključan…" message (S8).
+//   - a successful login clears failed_login_attempts + locked_until
+//     (S9/S11); we drive that path by clearing the lock via pgSql,
+//     since the only other unlock is the 15-min real-time expiry which
+//     isn't drivable from Cypress.
+//
+// The seeded klijent (klijent@banka.local / Klijent123!) is the target.
+
+const EMAIL = 'klijent@banka.local'
+const GOOD = 'Klijent123!'
+const WRONG = 'PogresnaLozinka9!'
+
+function attemptLogin(email: string, password: string) {
+  cy.visit('/login')
+  cy.findByLabelText('Email', { timeout: 45000 }).clear().type(email)
+  cy.findByLabelText('Lozinka').clear().type(password)
+  cy.findByRole('button', { name: /Prijavi se/ }).click()
+}
+
+describe('Celina 1 — zaključavanje naloga (live backend)', () => {
+  beforeEach(() => {
+    cy.resetBackend()
+  })
+
+  it('5 uzastopnih pogrešnih lozinki zaključava nalog (S7–S8)', () => {
+    // Attempts 1–4: wrong password → "Neispravni kredencijali", no lock yet.
+    for (let i = 0; i < 4; i++) {
+      attemptLogin(EMAIL, WRONG)
+      cy.contains('Neispravni kredencijali', { timeout: 10000 }).should('be.visible')
+    }
+
+    // Attempt 5 crosses the threshold → account is locked. The 5th
+    // failure returns the lockout message (Serbian copy from auth.go).
+    attemptLogin(EMAIL, WRONG)
+    cy.contains(/Nalog je zaključan zbog previše neuspešnih pokušaja/, { timeout: 10000 }).should(
+      'be.visible',
+    )
+
+    // Persisted state: counter at 5 + a non-null locked_until on the
+    // clients row. pgSql returns pipe-separated text; the seed has no
+    // other klijent@banka.local row so the single line is unambiguous.
+    cy.pgSql(
+      `select failed_login_attempts, (locked_until is not null) from "user".clients where email='${EMAIL}'`,
+    ).then((out) => {
+      const [attempts, locked] = String(out).trim().split('|')
+      expect(Number(attempts)).to.be.gte(5)
+      expect(locked).to.eq('t')
+    })
+  })
+
+  it('tačna lozinka dok je nalog zaključan i dalje biva odbijena (S8)', () => {
+    // Lock the account by exhausting the attempt budget.
+    for (let i = 0; i < 5; i++) {
+      attemptLogin(EMAIL, WRONG)
+    }
+    // Now try the correct password — still locked, still refused with the
+    // "privremeno zaključan" message rather than logging in.
+    attemptLogin(EMAIL, GOOD)
+    cy.contains(/Nalog je (privremeno )?zaključan/, { timeout: 10000 }).should('be.visible')
+    cy.url().should('include', '/login')
+  })
+
+  it('uspešna prijava nakon brisanja zaključavanja resetuje brojač (S9/S11)', () => {
+    // Lock the account.
+    for (let i = 0; i < 5; i++) {
+      attemptLogin(EMAIL, WRONG)
+    }
+    // Clear the lock directly (stands in for the 15-min real-time expiry,
+    // which isn't drivable from Cypress). The backend's own reset path on
+    // successful login does the same UPDATE (ResetFailedLogin).
+    cy.pgSql(
+      `update "user".clients set failed_login_attempts=0, locked_until=null where email='${EMAIL}'`,
+    )
+
+    // Correct password now logs in.
+    attemptLogin(EMAIL, GOOD)
+    cy.url({ timeout: 10000 }).should('not.include', '/login')
+
+    // And the counter is back at 0 (a successful login also clears it).
+    cy.pgSql(`select failed_login_attempts from "user".clients where email='${EMAIL}'`).then(
+      (out) => {
+        expect(Number(String(out).trim())).to.eq(0)
+      },
+    )
+  })
+
+  // SKIP (real-time expiry): the 15-min lockout window lifts on wall-clock
+  // time, not a cron we can pulse, and setClockOffset only moves the QA
+  // clock services read for business logic — the lockout comparison uses
+  // s.Clock.Now() so it *would* respect the offset, but advancing 15m+
+  // and waiting ~5s for propagation is slower + flakier than the pgSql
+  // clear path above, which exercises the identical UPDATE. Left as a
+  // note rather than a flaky timed test.
+})

--- a/cypress/e2e/celina2/notifications.cy.ts
+++ b/cypress/e2e/celina2/notifications.cy.ts
@@ -1,0 +1,100 @@
+/// <reference types="cypress" />
+
+// Live-backend c2 spec — in-app obaveštenja (todoSpec S19).
+//
+// After a successful payment the bank service emits an in-app
+// notification to the sender ("Potvrda plaćanja" — see
+// services/bank/internal/service/notifications.go:notifyPaymentSucceeded).
+// The shell's NotificationBell polls /api/v1/notifications, shows an
+// unread badge, and marks an item read on click.
+//
+// Note on "transfer" vs "payment": the prompt frames this as a transfer
+// between own accounts, but CreateTransfer does NOT notify — only
+// CreatePayment does (notifyPaymentSucceeded). So this drives the real
+// notification-producing path: a same-currency PAYMENT from the seeded
+// klijent's funded RSD account to a planted RSD recipient. The verified
+// flow is otherwise identical (verification-gated, 6-digit dialog).
+//
+// We plant the destination as an RSD account owned by the second seeded
+// client (klijent2@banka.local) with a syntactically valid, mod-11-clean
+// 18-digit number (digit-sum 66) so the form + backend both accept it.
+
+const TO_NUMBER = '160005412345678905'
+
+function plantRecipientAccount() {
+  // owner = klijent2, created_by = the bootstrap admin employee — both
+  // resolved by sub-select so the spec carries no hard-coded UUIDs.
+  // ON CONFLICT keeps the insert idempotent if a prior attempt left it.
+  cy.pgSql(`
+    insert into "bank".accounts
+      (number, name, owner_client_id, created_by_employee_id,
+       kind, subtype, currency, status,
+       balance, available_balance, maintenance_fee, daily_limit, monthly_limit)
+    select '${TO_NUMBER}', 'Primalac RSD',
+           (select id from "user".clients where email='klijent2@banka.local'),
+           (select id from "user".employees where email='admin@banka.local'),
+           'personal_checking_rsd', 'standard', 'RSD', 'active',
+           0, 0, 0, 120000, 1000000
+    on conflict (number) do nothing
+  `)
+}
+
+describe('Celina 2 — obaveštenja (live backend)', () => {
+  beforeEach(() => {
+    cy.resetBackend()
+    plantRecipientAccount()
+    cy.loginAsClient()
+  })
+
+  it('klijent izvrši plaćanje → zvono prikazuje nepročitano obaveštenje → označi pročitano (S19)', () => {
+    cy.visit('/banking/placanja')
+
+    // Pay 1.000 RSD from the seeded RSD account (250.000 raspoloživo).
+    cy.get('select[name="fromAccountId"]', { timeout: 15000 })
+      .find('option')
+      .contains('250.000,00')
+      .then(($opt) => cy.get('select[name="fromAccountId"]').select($opt.attr('value')!))
+    cy.get('input[name="recipientName"]').type('Primalac RSD')
+    cy.get('input[name="toAccountNumber"]').type(TO_NUMBER)
+    cy.get('input[name="amount"]').type('1000')
+    cy.get('input[name="paymentCode"]').clear().type('289')
+    cy.get('input[name="purpose"]').type('Test obaveštenja')
+    cy.findByRole('button', { name: /Pošalji plaćanje/ }).click()
+
+    // Verification — read the inline code, type it back.
+    cy.findByLabelText('verifikacioni-kod', { timeout: 10000 })
+      .invoke('text')
+      .then((code) => {
+        const trimmed = code.trim()
+        expect(trimmed).to.match(/^\d{6}$/)
+        cy.get('#verif-code').type(trimmed)
+        cy.findByRole('button', { name: /^Potvrdi$/ }).click()
+      })
+
+    // Payment success navigates to /banking/racuni; the shell (with the
+    // bell) is rendered on every banking page.
+    cy.url({ timeout: 15000 }).should('include', '/banking/racuni')
+
+    // The feed polls every 30s; force a reload so the freshly-emitted
+    // notification lands without waiting on the interval.
+    cy.reload()
+
+    // Open the bell (aria-label="Obaveštenja"). The unread badge renders
+    // as a count span inside the button; assert the panel content instead
+    // of the badge glyph for a stable check.
+    cy.findByRole('button', { name: 'Obaveštenja' }, { timeout: 15000 }).click()
+
+    // Panel lists the "Potvrda plaćanja" notification (unread → the
+    // "Označi sve kao pročitano" action is present while unread > 0).
+    cy.contains('Potvrda plaćanja', { timeout: 10000 }).should('be.visible')
+    cy.findByRole('button', { name: /Označi sve kao pročitano/ }).should('be.visible')
+
+    // Mark it read by clicking the row; once unread hits 0 the
+    // "Označi sve kao pročitano" action disappears (the markRead mutation
+    // invalidated the cache and the count dropped).
+    cy.contains('button', 'Potvrda plaćanja').click()
+    cy.findByRole('button', { name: /Označi sve kao pročitano/ }, { timeout: 10000 }).should(
+      'not.exist',
+    )
+  })
+})

--- a/cypress/e2e/celina2/quick-approve.cy.ts
+++ b/cypress/e2e/celina2/quick-approve.cy.ts
@@ -1,0 +1,102 @@
+/// <reference types="cypress" />
+
+// Live-backend c2 spec — Brzo odobravanje / quick-approve (todoSpec S12,
+// web side).
+//
+// Instead of typing the 6-digit code, the user taps "Odobri" on the
+// mobile app. The web dialog polls GET /verification/{id}/status every
+// 2s and, once the status flips to "approved", auto-proceeds id-only
+// (no X-Verification-Code header — proofHeaders sends X-Verification-Id
+// alone). We simulate the phone tap by calling
+// POST /api/v1/verification/{id}/approve with the same client's token
+// (ownership is enforced server-side in verification.Approve, so the
+// approving principal must be the record's owner).
+//
+// Flow: initiate a verification-gated PAYMENT → capture the id from the
+// /verification/request response → approve out-of-band → assert the
+// dialog auto-proceeds and the payment lands (redirect to /banking/racuni).
+//
+// Recipient: a planted RSD account on klijent2, valid mod-11 number.
+
+const TO_NUMBER = '160005412345678905'
+
+describe('Celina 2 — brzo odobravanje (live backend)', () => {
+  beforeEach(() => {
+    cy.resetBackend()
+    // Plant an RSD destination on the second seeded client.
+    cy.pgSql(`
+      insert into "bank".accounts
+        (number, name, owner_client_id, created_by_employee_id,
+         kind, subtype, currency, status,
+         balance, available_balance, maintenance_fee, daily_limit, monthly_limit)
+      select '${TO_NUMBER}', 'Primalac RSD',
+             (select id from "user".clients where email='klijent2@banka.local'),
+             (select id from "user".employees where email='admin@banka.local'),
+             'personal_checking_rsd', 'standard', 'RSD', 'active',
+             0, 0, 0, 120000, 1000000
+      on conflict (number) do nothing
+    `)
+    cy.loginAsClient()
+  })
+
+  it('telefon odobri zahtev → web dijalog automatski potvrdi plaćanje (S12)', () => {
+    // Capture the verification id the gateway issues when the dialog opens.
+    cy.intercept('POST', '/api/v1/verification/request').as('verifReq')
+
+    // A fresh client token for the out-of-band approve call. The web app
+    // keeps its token in memory (Zustand), so logging in again over the
+    // API is the clean way to get one we can attach to cy.request.
+    cy.request('POST', '/api/v1/auth/login', {
+      email: 'klijent@banka.local',
+      password: 'Klijent123!',
+    }).then((login) => {
+      cy.wrap(login.body.accessToken as string).as('clientToken')
+    })
+
+    // Fill + submit the payment to open the verification dialog.
+    cy.visit('/banking/placanja')
+    cy.get('select[name="fromAccountId"]', { timeout: 15000 })
+      .find('option')
+      .contains('250.000,00')
+      .then(($opt) => cy.get('select[name="fromAccountId"]').select($opt.attr('value')!))
+    cy.get('input[name="recipientName"]').type('Primalac RSD')
+    cy.get('input[name="toAccountNumber"]').type(TO_NUMBER)
+    cy.get('input[name="amount"]').type('900')
+    cy.get('input[name="paymentCode"]').clear().type('289')
+    cy.get('input[name="purpose"]').type('Brzo odobravanje')
+    cy.findByRole('button', { name: /Pošalji plaćanje/ }).click()
+
+    // The dialog issued a code; grab its id from the request response and
+    // approve it out-of-band as the same client (the phone "Odobri" tap).
+    cy.wait('@verifReq', { timeout: 15000 })
+      .its('response.body.verificationId')
+      .then((verificationId) => {
+        expect(verificationId, 'verification id issued').to.be.a('string')
+        cy.get<string>('@clientToken').then((token) => {
+          cy.request({
+            method: 'POST',
+            url: `/api/v1/verification/${verificationId}/approve`,
+            headers: { Authorization: `Bearer ${token}` },
+            body: {},
+          }).then((res) => {
+            // The endpoint confirms the record is now approved.
+            expect(res.status).to.eq(200)
+            expect(res.body.approved).to.eq(true)
+          })
+        })
+      })
+
+    // The dialog's 2s status poll sees "approved" and auto-proceeds the
+    // payment id-only (no typed code). Success navigates to /banking/racuni
+    // and the sender account is debited 250.000 - 900 = 249.100.
+    cy.url({ timeout: 20000 }).should('include', '/banking/racuni')
+    cy.contains('249.100,00', { timeout: 10000 }).should('be.visible')
+  })
+
+  // Best-effort limitation: if the web poll-mode auto-proceed proves
+  // timing-sensitive in CI (the status query is gated on !submit.isPending
+  // and refetches every 2s), the load-bearing assertion above is the
+  // approve endpoint returning {approved:true} — that alone proves the
+  // mobile quick-approve path marks the record approved. The subsequent
+  // auto-proceed + balance check exercises the web dialog reacting to it.
+})

--- a/cypress/e2e/celina2/scheduled-payments.cy.ts
+++ b/cypress/e2e/celina2/scheduled-payments.cy.ts
@@ -16,6 +16,25 @@
 
 const VALID_TO = '160005412345678905'
 
+// The schedule endpoint validates the recipient account exists (it's an
+// intra-bank payment), unlike the canned immediate-payment spec which
+// mocks the call. Plant a real RSD recipient so the create succeeds.
+// Owner = klijent2, created_by = bootstrap admin, resolved by sub-select.
+function plantRecipientAccount() {
+  cy.pgSql(`
+    insert into "bank".accounts
+      (number, name, owner_client_id, created_by_employee_id,
+       kind, subtype, currency, status,
+       balance, available_balance, maintenance_fee, daily_limit, monthly_limit)
+    select '${VALID_TO}', 'Stanar Komšija',
+           (select id from "user".clients where email='klijent2@banka.local'),
+           (select id from "user".employees where email='admin@banka.local'),
+           'personal_checking_rsd', 'standard', 'RSD', 'active',
+           0, 0, 0, 120000, 1000000
+    on conflict (number) do nothing
+  `)
+}
+
 // A YYYY-MM-DD value a few days out, computed from the browser clock so
 // the spec stays valid regardless of run date.
 function futureDate(days: number): string {
@@ -40,6 +59,7 @@ function fillPaymentBase() {
 describe('Celina 2 — zakazivanje plaćanja (live backend)', () => {
   beforeEach(() => {
     cy.resetBackend()
+    plantRecipientAccount()
     cy.loginAsClient()
   })
 
@@ -72,9 +92,13 @@ describe('Celina 2 — zakazivanje plaćanja (live backend)', () => {
       .should('be.visible')
       .and('contain.text', 'Zakazano')
 
-    // Cancel it → row disappears from the list.
+    // Cancel it → the row stays (history is kept) but its status flips to
+    // "Otkazano" and the Otkaži button disappears.
     cy.contains('tr', 'Stanar Komšija').findByRole('button', { name: /Otkaži/ }).click()
-    cy.contains('tr', 'Stanar Komšija', { timeout: 10000 }).should('not.exist')
+    cy.contains('tr', 'Stanar Komšija', { timeout: 10000 })
+      .should('contain.text', 'Otkazano')
+      .findByRole('button', { name: /Otkaži/ })
+      .should('not.exist')
   })
 
   it('odbija datum u prošlosti pre nego što otvori verifikaciju', () => {

--- a/cypress/e2e/celina2/scheduled-payments.cy.ts
+++ b/cypress/e2e/celina2/scheduled-payments.cy.ts
@@ -1,0 +1,94 @@
+/// <reference types="cypress" />
+
+// Live-backend c2 spec — zakazivanje plaćanja (todoSpec C2).
+//
+// The payment form (/banking/placanja) has a "Zakaži plaćanje" checkbox
+// that reveals a "Datum izvršenja" date input. With a future date the
+// submit routes through schedulePayment (verification-gated, same 6-digit
+// dialog as an immediate payment) and lands on /banking/placanja/zakazana
+// with the new row in status "Zakazano". Cancelling it removes the row.
+// A past date is rejected client-side before the dialog opens.
+//
+// Recipient: a syntactically valid 18-digit, mod-11-clean number
+// (160005412345678905, digit-sum 66 → 66 % 11 == 0). The same number is
+// used in payment.cy.ts; the schedule endpoint only validates the number
+// shape at create time (realization is a cron, not exercised here).
+
+const VALID_TO = '160005412345678905'
+
+// A YYYY-MM-DD value a few days out, computed from the browser clock so
+// the spec stays valid regardless of run date.
+function futureDate(days: number): string {
+  const d = new Date()
+  d.setDate(d.getDate() + days)
+  return d.toISOString().slice(0, 10)
+}
+
+function fillPaymentBase() {
+  // Pick the seeded RSD checking account (Tekući RSD, 250.000 raspoloživo).
+  cy.get('select[name="fromAccountId"]', { timeout: 15000 })
+    .find('option')
+    .contains('250.000,00')
+    .then(($opt) => cy.get('select[name="fromAccountId"]').select($opt.attr('value')!))
+  cy.get('input[name="recipientName"]').clear().type('Stanar Komšija')
+  cy.get('input[name="toAccountNumber"]').clear().type(VALID_TO)
+  cy.get('input[name="amount"]').clear().type('1200')
+  cy.get('input[name="paymentCode"]').clear().type('289')
+  cy.get('input[name="purpose"]').clear().type('Mesečna kirija')
+}
+
+describe('Celina 2 — zakazivanje plaćanja (live backend)', () => {
+  beforeEach(() => {
+    cy.resetBackend()
+    cy.loginAsClient()
+  })
+
+  it('zakaže plaćanje za budući datum → status Zakazano → otkaže ga', () => {
+    cy.visit('/banking/placanja')
+    fillPaymentBase()
+
+    // Enable scheduling + pick a future date.
+    cy.contains('label', 'Zakaži plaćanje').find('input[type="checkbox"]').check()
+    cy.get('input[name="scheduledDate"]').type(futureDate(5))
+
+    // Submit button copy flips to "Zakaži plaćanje".
+    cy.findByRole('button', { name: /Zakaži plaćanje/ }).click()
+
+    // Verification dialog opens (scheduling is gated). Read the real code
+    // the gateway returned inline and type it back.
+    cy.findByLabelText('verifikacioni-kod', { timeout: 10000 })
+      .invoke('text')
+      .then((code) => {
+        const trimmed = code.trim()
+        expect(trimmed).to.match(/^\d{6}$/)
+        cy.get('#verif-code').type(trimmed)
+        cy.findByRole('button', { name: /^Potvrdi$/ }).click()
+      })
+
+    // On success the FE navigates to the scheduled-payments list with the
+    // new row visible in status "Zakazano".
+    cy.url({ timeout: 15000 }).should('include', '/banking/placanja/zakazana')
+    cy.contains('tr', 'Stanar Komšija', { timeout: 10000 })
+      .should('be.visible')
+      .and('contain.text', 'Zakazano')
+
+    // Cancel it → row disappears from the list.
+    cy.contains('tr', 'Stanar Komšija').findByRole('button', { name: /Otkaži/ }).click()
+    cy.contains('tr', 'Stanar Komšija', { timeout: 10000 }).should('not.exist')
+  })
+
+  it('odbija datum u prošlosti pre nego što otvori verifikaciju', () => {
+    cy.visit('/banking/placanja')
+    fillPaymentBase()
+
+    cy.contains('label', 'Zakaži plaćanje').find('input[type="checkbox"]').check()
+    // Yesterday — must be rejected by the Zod superRefine (strictly future).
+    cy.get('input[name="scheduledDate"]').type(futureDate(-1))
+    cy.findByRole('button', { name: /Zakaži plaćanje/ }).click()
+
+    cy.contains('Datum mora biti u budućnosti').should('be.visible')
+    // No verification dialog opened, still on the form.
+    cy.findByLabelText('verifikacioni-kod').should('not.exist')
+    cy.url().should('include', '/banking/placanja')
+  })
+})

--- a/cypress/e2e/celina3/dca.cy.ts
+++ b/cypress/e2e/celina3/dca.cy.ts
@@ -1,0 +1,116 @@
+/// <reference types="cypress" />
+
+// Recurring orders / "Trajni nalog" (DCA — todoSpec C3 S47-S53). Live
+// against the seeded c3 stack.
+//
+// klijent@banka.local has trading.client + a USD trading account
+// ("Trgovinski USD") and the seeded RSD accounts from c2. The page lives
+// at /banking/trgovina/trajni-nalozi (src/components/trading/
+// RecurringOrdersPage.tsx) and is fully instrumented with data-cy hooks.
+//
+// The cron that materialises each recurring order into a real market
+// order is a scheduler job (pkg/schedule), not Cypress-drivable — so we
+// test the drivable surface: create BYAMOUNT / BYQUANTITY, the NextRun
+// stamp, pause, and cancel. resetBackend truncates trading.* so each test
+// starts with no recurring orders.
+
+function openDca() {
+  cy.loginAsClient()
+  cy.visit('/banking/trgovina/trajni-nalozi')
+  cy.contains('h1', 'Trajni nalog', { timeout: 15000 }).should('be.visible')
+}
+
+function pickSecurity(ticker: string) {
+  cy.get('[data-cy="recurring-security"]').find('option').contains(ticker).then((opt) => {
+    cy.get('[data-cy="recurring-security"]').select(opt.attr('value') as string)
+  })
+}
+
+function pickAnyAccount() {
+  // Any active account works for the form; pick the first non-placeholder.
+  cy.get('[data-cy="recurring-account"]').find('option').eq(1).then((opt) => {
+    cy.get('[data-cy="recurring-account"]').select(opt.attr('value') as string)
+  })
+}
+
+describe('Celina 3 — trajni nalog / DCA (S47-S53)', () => {
+  beforeEach(() => {
+    cy.resetBackend()
+    cy.clearExchangeOverride('XNYS')
+  })
+
+  it('S47-S48 — creates a BYAMOUNT recurring order (MSFT, 5000 RSD, MONTHLY) that is active with a NextRun', () => {
+    openDca()
+
+    pickSecurity('MSFT')
+    cy.get('[data-cy="recurring-mode"]').select('RECURRING_MODE_BYAMOUNT')
+    cy.get('[data-cy="recurring-amount"]').clear().type('5000')
+    cy.get('[data-cy="recurring-cadence"]').select('MONTHLY')
+    pickAnyAccount()
+    cy.get('[data-cy="recurring-submit"]').click()
+
+    // The new order shows up in "Moji trajni nalozi" — active, MSFT,
+    // 5.000,00 RSD, with a "Sledeće:" next-run timestamp.
+    cy.get('[data-cy="recurring-list"]', { timeout: 15000 }).find('[data-cy="recurring-item"]').should('have.length', 1)
+    cy.get('[data-cy="recurring-item"]').within(() => {
+      cy.get('[data-cy="recurring-item-ticker"]').should('contain', 'MSFT')
+      cy.get('[data-cy="recurring-item-status"]').should('contain', 'Aktivan')
+      cy.contains('Sledeće:').should('be.visible')
+    })
+
+    // SKIP (cron-driven): S49/S50/S53 — the materialisation of this
+    // recurring order into a real market order at next_run (and the
+    // skip-on-insufficient-funds path) is a scheduler job; covered by
+    // backend unit tests. We assert the persisted row + next_run instead.
+    cy.pgSql(`
+      SELECT mode, amount_rsd, cadence, active, (next_run IS NOT NULL)
+        FROM "trading".recurring_orders ORDER BY created_at DESC LIMIT 1
+    `).then((row) => {
+      expect(row).to.contain('BYAMOUNT')
+      expect(row).to.contain('MONTHLY')
+      // active=true and next_run is set.
+      expect(row).to.contain('|t|t')
+    })
+  })
+
+  it('S51 — creates a BYQUANTITY recurring order (AAPL, 5, WEEKLY)', () => {
+    openDca()
+
+    pickSecurity('AAPL')
+    cy.get('[data-cy="recurring-mode"]').select('RECURRING_MODE_BYQUANTITY')
+    cy.get('[data-cy="recurring-quantity"]').clear().type('5')
+    cy.get('[data-cy="recurring-cadence"]').select('WEEKLY')
+    pickAnyAccount()
+    cy.get('[data-cy="recurring-submit"]').click()
+
+    cy.get('[data-cy="recurring-item"]', { timeout: 15000 }).should('have.length', 1)
+    cy.get('[data-cy="recurring-item"]').within(() => {
+      cy.get('[data-cy="recurring-item-ticker"]').should('contain', 'AAPL')
+      // BYQUANTITY renders "5 kom.".
+      cy.contains('5 kom.').should('be.visible')
+      cy.get('[data-cy="recurring-item-status"]').should('contain', 'Aktivan')
+    })
+  })
+
+  it('S52 — pauses an active recurring order, then cancels it (gone from the list)', () => {
+    openDca()
+
+    pickSecurity('MSFT')
+    cy.get('[data-cy="recurring-mode"]').select('RECURRING_MODE_BYAMOUNT')
+    cy.get('[data-cy="recurring-amount"]').clear().type('5000')
+    cy.get('[data-cy="recurring-cadence"]').select('MONTHLY')
+    pickAnyAccount()
+    cy.get('[data-cy="recurring-submit"]').click()
+    cy.get('[data-cy="recurring-item"]', { timeout: 15000 }).should('have.length', 1)
+
+    // Pause → status flips to "Pauziran" and a "Nastavi" affordance appears.
+    cy.get('[data-cy="recurring-pause"]').click()
+    cy.get('[data-cy="recurring-item-status"]', { timeout: 10000 }).should('contain', 'Pauziran')
+    cy.get('[data-cy="recurring-resume"]').should('be.visible')
+
+    // Cancel → row disappears (cancelled orders drop out of the active list).
+    cy.get('[data-cy="recurring-cancel"]').click()
+    cy.get('[data-cy="recurring-empty"]', { timeout: 10000 }).should('be.visible')
+    cy.get('[data-cy="recurring-item"]').should('not.exist')
+  })
+})

--- a/cypress/e2e/celina3/dividends.cy.ts
+++ b/cypress/e2e/celina3/dividends.cy.ts
@@ -1,0 +1,75 @@
+/// <reference types="cypress" />
+
+// Dividends (todoSpec C3 S54-S59). Live against the seeded c3 stack.
+//
+// The quarterly dividend payout (S54-S58: who gets paid, the
+// shares × price × yield/4 computation, the same-currency / default-
+// currency / RSD account-selection fallback, and the 15% capital-gains
+// tax on client holders) is a scheduler-driven cron and is NOT
+// Cypress-drivable — it's covered by backend unit tests.
+//
+// SKIP (cron): S54-S58 payout computation + account selection + tax.
+//
+// This spec focuses on the DISPLAY (S59): the per-position portfolio
+// detail page (/banking/portfolio/$securityId,
+// src/routes/_authed/banking/portfolio/$securityId.tsx) renders the
+// dividend history (date + amount) for the position. We plant a payout
+// row directly (as the cron would write it) and assert it renders.
+//
+// The dividends list endpoint scopes to the caller's (user_id, user_kind)
+// from the JWT; for klijent that's the client's UUID + 'client'.
+// resetBackend reseeds klijent with a fresh UUID, so we read it back from
+// the DB and plant against it. dividend_payouts has no FK to accounts and
+// isn't in the resetBackend truncate set, so we delete the client's prior
+// rows first to stay hermetic across re-runs.
+
+describe('Celina 3 — dividende (display, S59)', () => {
+  beforeEach(() => {
+    cy.resetBackend()
+  })
+
+  it('S59 — portfolio position detail shows planted dividend history (date + amount)', () => {
+    // Resolve the freshly-seeded klijent's client id + AAPL's security id.
+    cy.pgSql(`SELECT id FROM "user".clients WHERE email = 'klijent@banka.local'`).then((clientId) => {
+      const cid = clientId.trim()
+      expect(cid, 'klijent client id').to.match(/^[0-9a-f-]{36}$/)
+
+      cy.pgSql(`SELECT id FROM "trading".securities WHERE ticker = 'AAPL' AND type = 'stock' LIMIT 1`).then((secId) => {
+        const sid = secId.trim()
+        expect(sid, 'AAPL security id').to.match(/^[0-9a-f-]{36}$/)
+
+        // Plant a dividend payout exactly as the quarterly cron would:
+        // 10 shares × $190.55 × (yield/4) ≈ $47.64 gross, paid in USD,
+        // with the 15% capital-gains tax recorded in RSD. account_id is a
+        // free-text column on this table, so a placeholder is fine for the
+        // S59 display assertion.
+        cy.pgSql(`DELETE FROM "trading".dividend_payouts WHERE user_id = '${cid}'`)
+        cy.pgSql(`
+          INSERT INTO "trading".dividend_payouts
+            (user_id, user_kind, security_id, quantity, price, gross_amount,
+             currency, account_id, tax_rsd, op_id, status, paid_at)
+          VALUES
+            ('${cid}', 'client', '${sid}', 10, 190.55, 47.6375,
+             'USD', 'seed-acct', 837.66, gen_random_uuid(), 'paid', now())
+        `)
+
+        cy.loginAsClient()
+        cy.visit(`/banking/portfolio/${sid}`)
+
+        cy.get('[data-cy="dividend-history"]', { timeout: 15000 }).should('be.visible')
+        cy.get('[data-cy="dividend-history"]').within(() => {
+          cy.contains('Isplaćene dividende').should('be.visible')
+          // S59: the history row carries the quantity, the gross amount in
+          // the listing currency (USD), and the tax (RSD). formatMoney
+          // renders with '.' thousands / ',' decimal, two decimals always:
+          // 47.6375 → "47,64 USD", 837.66 → "837,66".
+          cy.contains('td', '10').should('exist')
+          cy.contains('td', /47,64\s+USD/).should('exist')
+          cy.contains('td', '837,66').should('exist')
+          // A date cell renders (DD.MM.YYYY via formatDate of paid_at).
+          cy.contains('td', /\d{2}\.\d{2}\.\d{4}/).should('exist')
+        })
+      })
+    })
+  })
+})

--- a/cypress/e2e/celina3/forex-forwards.cy.ts
+++ b/cypress/e2e/celina3/forex-forwards.cy.ts
@@ -1,0 +1,107 @@
+/// <reference types="cypress" />
+
+// Terminski valutni ugovori / forex forwards (todoSpec C3). Live against
+// the seeded c3 stack.
+//
+// Client surface: /banking/terminski (src/routes/_authed/banking/
+// terminski.tsx) — fill base currency / notional / settlement date to get
+// a forward quote (forward rate + commission), conclude it (verification-
+// gated, spec p.11), and cancel an active one.
+//
+// Supervisor surface: /portal/terminski-spreadovi
+// (src/routes/_authed/portal/terminski-spreadovi.tsx) — set the annualised
+// spread factor per currency pair that feeds the forward-rate formula.
+//
+// The forms use RHF register (no data-cy), so we target inputs by their
+// forwarded name attribute and scope by the form aria-label.
+//
+// resetBackend truncates bank.* (incl. reservations) + trading.*, so each
+// test starts with no forwards. USD/RSD FX rates are seeded (the trading
+// account is USD), so the USD-leg quote resolves.
+
+// A settlement date comfortably in the future (forward needs daysToSettlement > 0).
+function futureDate(daysAhead: number): string {
+  const d = new Date()
+  d.setUTCDate(d.getUTCDate() + daysAhead)
+  return d.toISOString().slice(0, 10)
+}
+
+describe('Celina 3 — terminski valutni ugovori (forex forwards)', () => {
+  beforeEach(() => {
+    cy.resetBackend()
+  })
+
+  it('quotes a forward (rate + commission), concludes it (verification-gated), then cancels it', () => {
+    cy.loginAsClient()
+    cy.visit('/banking/terminski')
+    cy.contains('h1', 'Terminski valutni ugovori', { timeout: 15000 }).should('be.visible')
+
+    cy.get('form[aria-label="Nov terminski ugovor"]').within(() => {
+      cy.get('select[name="baseCurrency"]').select('CURRENCY_USD')
+      cy.get('input[name="settlementDate"]').type(futureDate(90))
+      cy.get('input[name="notional"]').clear().type('1000')
+    })
+
+    // The quote box renders once the BE returns forward rate + commission.
+    cy.contains('Terminski kurs:', { timeout: 15000 }).should('be.visible')
+    cy.contains('Provizija:').should('be.visible')
+    cy.contains('Obaveza (rezerviše se):').should('be.visible')
+
+    // Capture the dev-mode verification code (spec p.11) then conclude.
+    cy.intercept('POST', '/api/v1/verification/request').as('verifReq')
+    cy.contains('button', /Zaključi ugovor/).click()
+
+    cy.wait('@verifReq').then((i) => {
+      const code = (i.response?.body as { code?: string })?.code as string
+      expect(code, 'dev-mode verification code').to.match(/^\d{6}$/)
+      cy.get('#verif-code').type(code)
+      cy.findByRole('button', { name: /^Potvrdi$/ }).click()
+    })
+
+    // The forward appears in the list with status "Aktivan".
+    cy.contains('h2', 'Moji terminski ugovori').should('be.visible')
+    cy.contains('tr', 'Aktivan', { timeout: 15000 }).should('be.visible')
+
+    // Cancel the active forward — status flips to "Otkazan".
+    cy.contains('tr', 'Aktivan').contains('button', 'Otkaži').click()
+    cy.contains('tr', 'Otkazan', { timeout: 10000 }).should('be.visible')
+  })
+
+  it('rejects a past settlement date (no quote, conclude disabled)', () => {
+    cy.loginAsClient()
+    cy.visit('/banking/terminski')
+    cy.contains('h1', 'Terminski valutni ugovori', { timeout: 15000 }).should('be.visible')
+
+    cy.get('form[aria-label="Nov terminski ugovor"]').within(() => {
+      cy.get('select[name="baseCurrency"]').select('CURRENCY_USD')
+      cy.get('input[name="notional"]').clear().type('1000')
+      // A date in the past — the quote query is gated on
+      // settlementDate > now, so no quote box renders.
+      cy.get('input[name="settlementDate"]').type(futureDate(-30))
+    })
+
+    cy.contains('Terminski kurs:').should('not.exist')
+    // With no quote the conclude button stays disabled.
+    cy.contains('button', /Zaključi ugovor/).should('be.disabled')
+  })
+
+  it('supervisor sets a spread factor for a pair and it persists', () => {
+    cy.loginAsSupervisor()
+    cy.visit('/portal/terminski-spreadovi')
+    cy.contains('h1', 'Terminski ugovori — spread faktor', { timeout: 15000 }).should('be.visible')
+
+    cy.get('form[aria-label="Podešavanje spread faktora"]').within(() => {
+      cy.get('select[name="baseCurrency"]').select('CURRENCY_USD')
+      cy.get('input[name="spreadFactor"]').clear().type('0.035')
+      cy.contains('button', /Sačuvaj/).click()
+    })
+
+    // The configured pair shows up in "Podešeni parovi" with the saved factor.
+    cy.contains('h2', 'Podešeni parovi').should('be.visible')
+    cy.contains('tr', '0.035', { timeout: 15000 }).should('be.visible')
+
+    // Persists across a reload (read back from the BE).
+    cy.reload()
+    cy.contains('tr', '0.035', { timeout: 15000 }).should('be.visible')
+  })
+})

--- a/cypress/e2e/celina3/price-alerts.cy.ts
+++ b/cypress/e2e/celina3/price-alerts.cy.ts
@@ -1,0 +1,94 @@
+/// <reference types="cypress" />
+
+// Price alerts (todoSpec C3 S26-S29). Live against the seeded c3 stack.
+//
+// The alert control (src/components/trading/PriceAlertCard.tsx) embeds
+// on every tradable security's detail page. A user sets a one-shot
+// threshold (ABOVE / BELOW); a backend sweep emails them once on the
+// crossing and deactivates the alert. The actual fire is cron-driven and
+// not Cypress-drivable; we plant the crossing via cy.pgSql to assert the
+// deactivated-row display, and otherwise exercise create/list/validation.
+//
+// resetBackend truncates trading.* so each test starts with no alerts.
+
+function openAaplDetail() {
+  cy.visit('/banking/trgovina')
+  cy.contains('h1', 'Trgovina', { timeout: 15000 }).should('be.visible')
+  cy.get('[data-cy="filter-search"]').type('AAPL')
+  cy.contains('tr', 'AAPL', { timeout: 10000 }).click()
+  cy.url({ timeout: 10000 }).should('match', /\/banking\/trgovina\/[0-9a-f-]+/)
+}
+
+describe('Celina 3 — price alerts (S26-S29)', () => {
+  beforeEach(() => {
+    cy.resetBackend()
+    cy.clearExchangeOverride('XNYS')
+    cy.loginAsClient()
+  })
+
+  it('S26-S27 — creates an ABOVE alert and an active BELOW alert, both listed', () => {
+    openAaplDetail()
+
+    cy.get('[data-cy="price-alert-card"]').within(() => {
+      // S26: ABOVE threshold. AAPL ASK is ~190.55; pick a far threshold
+      // so the alert never trips during the test.
+      cy.get('#pa-condition').select('PRICE_ALERT_CONDITION_ABOVE')
+      cy.get('[data-cy="price-alert-threshold"]').clear().type('500')
+      cy.get('[data-cy="price-alert-submit"]').click()
+
+      // S27: BELOW threshold on the same security.
+      cy.get('#pa-condition').select('PRICE_ALERT_CONDITION_BELOW')
+      cy.get('[data-cy="price-alert-threshold"]').clear().type('10')
+      cy.get('[data-cy="price-alert-submit"]').click()
+
+      // Both show as active in the list (active alerts render a "Otkaži"
+      // affordance; deactivated ones render "(aktiviran)" instead).
+      cy.get('[data-cy="price-alert-list"]', { timeout: 10000 })
+        .find('li')
+        .should('have.length', 2)
+      cy.get('[data-cy="price-alert-list"]').should('contain', 'pređe iznad')
+      cy.get('[data-cy="price-alert-list"]').should('contain', 'padne ispod')
+      cy.contains('(aktiviran)').should('not.exist')
+    })
+  })
+
+  it('S28 — rejects a non-positive threshold (client-side validation)', () => {
+    openAaplDetail()
+    cy.get('[data-cy="price-alert-card"]').within(() => {
+      cy.get('[data-cy="price-alert-threshold"]').clear().type('0')
+      cy.get('[data-cy="price-alert-submit"]').click()
+      // Zod refine: "Prag mora biti veći od nule".
+      cy.contains('Prag mora biti veći od nule').should('be.visible')
+      // No alert row was created.
+      cy.get('[data-cy="price-alert-list"]').should('not.exist')
+    })
+  })
+
+  it('S29 — a triggered alert shows as deactivated (crossing planted via DB)', () => {
+    openAaplDetail()
+    cy.get('[data-cy="price-alert-card"]').within(() => {
+      cy.get('#pa-condition').select('PRICE_ALERT_CONDITION_ABOVE')
+      cy.get('[data-cy="price-alert-threshold"]').clear().type('500')
+      cy.get('[data-cy="price-alert-submit"]').click()
+      cy.get('[data-cy="price-alert-list"]', { timeout: 10000 }).find('li').should('have.length', 1)
+    })
+
+    // SKIP (cron-driven): the price-cross sweep that flips is_active and
+    // emails the user is a scheduler job, not Cypress-drivable. Simulate
+    // the post-sweep state directly: deactivate the row + stamp a
+    // triggered_at, exactly as the sweep would.
+    cy.pgSql(`
+      UPDATE "trading".price_alerts
+         SET is_active = false, triggered_at = now()
+       WHERE id = (SELECT id FROM "trading".price_alerts ORDER BY created_at DESC LIMIT 1)
+    `)
+
+    cy.reload()
+    cy.get('[data-cy="price-alert-card"]').within(() => {
+      // The deactivated alert renders the "(aktiviran)" marker and no
+      // longer offers an "Otkaži" affordance.
+      cy.contains('(aktiviran)', { timeout: 10000 }).should('be.visible')
+      cy.contains('button', 'Otkaži').should('not.exist')
+    })
+  })
+})

--- a/cypress/e2e/celina3/watchlist.cy.ts
+++ b/cypress/e2e/celina3/watchlist.cy.ts
@@ -12,9 +12,13 @@
 // resetBackend truncates trading.* incl. any watchlist rows, so each
 // test starts with no lists.
 
-function openSecurityDetail(ticker: string) {
+// The catalog defaults to the "Akcije" (stock) tab; futures/forex/options
+// live under their own tabs and the search box filters within the active
+// tab. Pass the security type so we land on the right tab before searching.
+function openSecurityDetail(ticker: string, tab: string = 'SECURITY_TYPE_STOCK') {
   cy.visit('/banking/trgovina')
   cy.contains('h1', 'Trgovina', { timeout: 15000 }).should('be.visible')
+  cy.get(`[data-cy="tab-${tab}"]`, { timeout: 10000 }).click()
   cy.get('[data-cy="filter-search"]').type(ticker)
   cy.contains('tr', ticker, { timeout: 10000 }).click()
   cy.url({ timeout: 10000 }).should('match', /\/banking\/trgovina\/[0-9a-f-]+/)
@@ -94,7 +98,7 @@ describe('Celina 3 — liste za praćenje (S35-S39)', () => {
     })
 
     // Add the future (CL) to the same list via its detail page.
-    openSecurityDetail('CL')
+    openSecurityDetail('CL', 'SECURITY_TYPE_FUTURE')
     cy.get('[data-cy="watchlist-add-card"]').within(() => {
       // The list now exists, so the default (non-creating) control is shown.
       cy.get('[data-cy="watchlist-select"]').find('option').contains('Mešovito').then((opt) => {

--- a/cypress/e2e/celina3/watchlist.cy.ts
+++ b/cypress/e2e/celina3/watchlist.cy.ts
@@ -1,0 +1,121 @@
+/// <reference types="cypress" />
+
+// Watchlists (todoSpec C3 S35-S39). Live against the seeded c3 stack.
+//
+// klijent@banka.local has trading.client. The watchlist add control
+// (src/components/trading/WatchlistCard.tsx) embeds on every security
+// detail page; the dedicated list view lives at
+// /banking/trgovina/watchlist (src/components/trading/WatchlistPage.tsx).
+// Both surfaces are well-instrumented with data-cy hooks already, so no
+// component edits are needed here.
+//
+// resetBackend truncates trading.* incl. any watchlist rows, so each
+// test starts with no lists.
+
+function openSecurityDetail(ticker: string) {
+  cy.visit('/banking/trgovina')
+  cy.contains('h1', 'Trgovina', { timeout: 15000 }).should('be.visible')
+  cy.get('[data-cy="filter-search"]').type(ticker)
+  cy.contains('tr', ticker, { timeout: 10000 }).click()
+  cy.url({ timeout: 10000 }).should('match', /\/banking\/trgovina\/[0-9a-f-]+/)
+}
+
+describe('Celina 3 — liste za praćenje (S35-S39)', () => {
+  beforeEach(() => {
+    cy.resetBackend()
+    cy.clearExchangeOverride('XNYS')
+    cy.loginAsClient()
+  })
+
+  it('S35-S36 — adds MSFT to a freshly created named watchlist', () => {
+    openSecurityDetail('MSFT')
+
+    cy.get('[data-cy="watchlist-add-card"]').within(() => {
+      // S36: create a new named list and add the on-screen security to
+      // it in one shot (WatchlistCard's create→add chain).
+      cy.get('[data-cy="watchlist-new-toggle"]').click()
+      cy.get('[data-cy="watchlist-new-name"]').type('Tech akcije')
+      cy.get('[data-cy="watchlist-new-submit"]').click()
+
+      // S35: the security shows as a member of the list it was added to.
+      cy.get('[data-cy="watchlist-membership"]', { timeout: 10000 })
+        .should('contain', 'Tech akcije')
+    })
+
+    // S36: the list shows up on the dedicated watchlist page with MSFT.
+    cy.visit('/banking/trgovina/watchlist')
+    cy.contains('h1', 'Liste za praćenje', { timeout: 15000 }).should('be.visible')
+    cy.get('[data-cy="watchlist"]').should('have.length', 1)
+    cy.get('[data-cy="watchlist-name"]').should('contain', 'Tech akcije')
+    cy.get('[data-cy="watchlist-item"]').should('contain', 'MSFT')
+  })
+
+  it('S37-S38 — list shows price/daily-change, supports remove + quick-order deep link', () => {
+    // Seed a list with one item via the detail page, then exercise the
+    // list view.
+    openSecurityDetail('MSFT')
+    cy.get('[data-cy="watchlist-add-card"]').within(() => {
+      cy.get('[data-cy="watchlist-new-toggle"]').click()
+      cy.get('[data-cy="watchlist-new-name"]').type('Tech akcije')
+      cy.get('[data-cy="watchlist-new-submit"]').click()
+      cy.get('[data-cy="watchlist-membership"]', { timeout: 10000 }).should('contain', 'Tech akcije')
+    })
+
+    cy.visit('/banking/trgovina/watchlist')
+    cy.get('[data-cy="watchlist-item"]', { timeout: 15000 }).should('have.length', 1)
+
+    // S35/S37: each item renders a current price (formatMoney → has a
+    // currency suffix like "USD") next to the ticker.
+    cy.get('[data-cy="watchlist-item"]').first().should('contain', 'MSFT').and('contain', 'USD')
+
+    // S38: the quick-order link lands on the security detail with the
+    // order form prefilled for a BUY.
+    cy.get('[data-cy="watchlist-quick-order"]').first().click()
+    cy.url({ timeout: 10000 })
+      .should('match', /\/banking\/trgovina\/[0-9a-f-]+/)
+      .and('include', 'direction=buy')
+    cy.get('#order-form', { timeout: 10000 }).should('exist')
+
+    // S37: remove the item — list goes empty.
+    cy.visit('/banking/trgovina/watchlist')
+    cy.get('[data-cy="watchlist-item-remove"]', { timeout: 15000 }).first().click()
+    cy.get('[data-cy="watchlist-item"]').should('not.exist')
+  })
+
+  it('S39 — filters watchlist items by security type', () => {
+    // Build a list with a stock (MSFT) and a future (CL) so the type
+    // filter has something to hide.
+    openSecurityDetail('MSFT')
+    cy.get('[data-cy="watchlist-add-card"]').within(() => {
+      cy.get('[data-cy="watchlist-new-toggle"]').click()
+      cy.get('[data-cy="watchlist-new-name"]').type('Mešovito')
+      cy.get('[data-cy="watchlist-new-submit"]').click()
+      cy.get('[data-cy="watchlist-membership"]', { timeout: 10000 }).should('contain', 'Mešovito')
+    })
+
+    // Add the future (CL) to the same list via its detail page.
+    openSecurityDetail('CL')
+    cy.get('[data-cy="watchlist-add-card"]').within(() => {
+      // The list now exists, so the default (non-creating) control is shown.
+      cy.get('[data-cy="watchlist-select"]').find('option').contains('Mešovito').then((opt) => {
+        cy.get('[data-cy="watchlist-select"]').select(opt.attr('value') as string)
+      })
+      cy.get('[data-cy="watchlist-add-submit"]').click()
+      cy.get('[data-cy="watchlist-membership"]', { timeout: 10000 }).should('contain', 'Mešovito')
+    })
+
+    cy.visit('/banking/trgovina/watchlist')
+    cy.get('[data-cy="watchlist-item"]', { timeout: 15000 }).should('have.length', 2)
+
+    // Filter to "Akcija" (stock) — only MSFT remains visible.
+    cy.get('[data-cy="watchlist-type-filter"]').find('option').contains(/Akcij/).then((opt) => {
+      cy.get('[data-cy="watchlist-type-filter"]').select(opt.attr('value') as string)
+    })
+    cy.get('[data-cy="watchlist-item"]').should('have.length', 1)
+    cy.get('[data-cy="watchlist-item"]').first().should('contain', 'MSFT')
+
+    // Clear the filter — both items return.
+    cy.get('[data-cy="watchlist-type-filter"]').select('')
+    cy.get('[data-cy="watchlist-item"]').should('have.length', 2)
+  })
+})

--- a/cypress/e2e/celina4/fund-dividends.cy.ts
+++ b/cypress/e2e/celina4/fund-dividends.cy.ts
@@ -1,0 +1,130 @@
+/// <reference types="cypress" />
+
+export {}
+
+// todoSpec C4 S69-S72 — fund dividend handling.
+//
+//   S70 — the fund manager (supervisor) toggles the fund's
+//         "Reinvestiranje dividendi" flag; it persists across reloads.
+//   S71 — the per-client dividend-distribution history renders on the
+//         fund detail ("Raspodela dividendi" table).
+//
+// The actual dividend *distribution computation* runs in the quarterly
+// dividend cron (ListDividendCandidates → SettleDividend → proportional
+// split into fund_dividend_distributions). That is not Cypress-drivable
+// from a single stack — SKIP (cron), see note below. We plant a
+// fund_dividend_distributions row via cy.pgSql and assert the FE renders
+// it, which is what the new S71 UI surfaces.
+
+const FUND_NAME = 'Dividend Fond'
+const FUND_MIN = 1_000
+
+// Resolve any seeded security id for the dividend_payouts FK (the
+// payout's security is irrelevant to the FE distribution table, which
+// only reads client/units/amount).
+function anySecurityId(): Cypress.Chainable<string> {
+  return cy
+    .pgSql(`SELECT id FROM "trading".securities WHERE type = 'stock' LIMIT 1`)
+    .then((s) => {
+      const id = (s as string).trim()
+      if (!id) throw new Error('no seeded security to anchor dividend payout')
+      return id
+    })
+}
+
+describe('Celina 4 — fund dividends (S70 reinvest toggle, S71 history)', () => {
+  beforeEach(() => {
+    cy.resetBackend()
+  })
+
+  it('S70 — menadžer (supervizor) menja reinvestiranje dividendi i promena se zadržava', () => {
+    // Create the fund through the UI so we exercise the real create path
+    // and land on the detail page.
+    cy.loginAsSupervisor()
+    cy.visit('/portal/fondovi')
+    cy.contains('h1', 'Investicioni fondovi', { timeout: 15000 }).should('be.visible')
+    cy.get('[data-cy="funds-create"]').click()
+    cy.contains('Kreiraj fond').should('be.visible')
+    cy.get('[data-cy="fund-name"]').type(FUND_NAME)
+    cy.get('[data-cy="fund-description"]').type('Fond za S70/S71 dividend test')
+    cy.get('[data-cy="fund-min"]').type(String(FUND_MIN))
+    cy.get('[data-cy="fund-create-submit"]').click()
+
+    cy.url({ timeout: 15000 }).should('match', /\/portal\/fondovi\/[0-9a-f-]+/)
+    cy.contains('[data-cy="fund-detail-name"]', FUND_NAME).should('be.visible')
+
+    // Default is "Isključeno". Toggle on; the button re-renders from the
+    // refetched fund (data-on flips to "true"); reload to prove it stuck.
+    cy.get('[data-cy="fund-reinvest-toggle"]')
+      .should('have.attr', 'data-on', 'false')
+      .and('contain', 'Isključeno')
+      .click()
+    cy.get('[data-cy="fund-reinvest-toggle"]', { timeout: 15000 })
+      .should('have.attr', 'data-on', 'true')
+      .and('contain', 'Uključeno')
+
+    cy.reload()
+    cy.get('[data-cy="fund-reinvest-toggle"]', { timeout: 15000 })
+      .should('have.attr', 'data-on', 'true')
+      .and('contain', 'Uključeno')
+
+    // Toggle back off — the mutation round-trips both directions.
+    cy.get('[data-cy="fund-reinvest-toggle"]').click()
+    cy.get('[data-cy="fund-reinvest-toggle"]', { timeout: 15000 })
+      .should('have.attr', 'data-on', 'false')
+      .and('contain', 'Isključeno')
+  })
+
+  it('S71 — raspodela dividendi po klijentima se prikazuje u istoriji fonda', () => {
+    // SKIP (cron): distribution computation — the quarterly dividend cron
+    // computes + writes fund_dividend_distributions. Here we plant one
+    // distribution row directly so the new "Raspodela dividendi" table is
+    // asserted to render the persisted attribution.
+    cy.loginAsSupervisor()
+    cy.visit('/portal/fondovi')
+    cy.contains('h1', 'Investicioni fondovi', { timeout: 15000 }).should('be.visible')
+    cy.get('[data-cy="funds-create"]').click()
+    cy.get('[data-cy="fund-name"]').type(FUND_NAME)
+    cy.get('[data-cy="fund-min"]').type(String(FUND_MIN))
+    cy.get('[data-cy="fund-create-submit"]').click()
+    cy.url({ timeout: 15000 }).should('match', /\/portal\/fondovi\/[0-9a-f-]+/)
+    cy.contains('[data-cy="fund-detail-name"]', FUND_NAME).should('be.visible')
+
+    cy.url().then((url) => {
+      const fundId = url.match(/\/portal\/fondovi\/([0-9a-f-]+)/)![1]
+
+      // Plant a dividend_payouts row (the distribution FK target) for the
+      // fund, then a fund_dividend_distributions row attributing 250 RSD
+      // to one investor at a 30/100-unit share snapshot.
+      const payoutId = crypto.randomUUID()
+      const clientId = crypto.randomUUID()
+      anySecurityId().then((securityId) => {
+        cy.pgSql(
+          `INSERT INTO "trading".dividend_payouts
+             (id, user_id, user_kind, security_id, quantity, price,
+              gross_amount, currency, account_id, tax_rsd, op_id, status, paid_at)
+           VALUES ('${payoutId}', '${clientId}', 'fund', '${securityId}', 100,
+              '10.0000', '1000.0000', 'RSD', '${crypto.randomUUID()}', '0',
+              '${crypto.randomUUID()}', 'paid', now())`,
+        )
+        cy.pgSql(
+          `INSERT INTO "trading".fund_dividend_distributions
+             (fund_id, dividend_payout_id, client_id,
+              share_units, fund_total_units, amount_rsd)
+           VALUES ('${fundId}', '${payoutId}', '${clientId}',
+              '30.00000000', '100.00000000', '250.0000')`,
+        )
+
+        // Reload so the dividends query refetches the planted row.
+        cy.reload()
+        cy.contains('Raspodela dividendi', { timeout: 15000 }).should('be.visible')
+        // The history table now has one attribution row (was the empty
+        // "Fond još nije primio dividendu." state before).
+        cy.contains('Fond još nije primio dividendu.').should('not.exist')
+        cy.contains('tr', '30').should('contain', '100') // share / total units
+        // Amount renders in the RSD column.
+        cy.contains('tr', '250').should('be.visible')
+      })
+    })
+  })
+})

--- a/cypress/e2e/celina4/otc-offer-actions.cy.ts
+++ b/cypress/e2e/celina4/otc-offer-actions.cy.ts
@@ -1,0 +1,368 @@
+/// <reference types="cypress" />
+
+export {}
+
+// todoSpec C4 "Automatska promena stanja pregovora" — the extended OTC
+// offer state machine. An open offer can now also transition to:
+//
+//   * cancelled (Otkazana) — the ORIGINATOR (the party who proposed the
+//     live iteration) pulls their own open offer.
+//   * rejected  (Odbijena) — the COUNTERPARTY declines the latest open
+//     offer.
+//
+// (The 3-business-day inactivity auto-expiry → expired is cron-driven and
+// not Cypress-drivable from a single stack — SKIP, see note below.)
+//
+// Coverage here drives the NEW UI surfaces in OTCThreadModal:
+//   - the "Otkaži ponudu" button (data-cy=otc-cancel), shown to the
+//     originator while waiting on the other side, and
+//   - the "Odbij ponudu" button (data-cy=otc-reject), shown to the
+//     counterparty alongside the counter form.
+// Each action closes the modal + the thread drops out of the active
+// ("Aktivne ponude") list — ListOTCThreads defaults to status='open', so
+// a cancelled/rejected thread is no longer active. We assert the drop and
+// cross-check the persisted terminal status (cancelled/rejected) via
+// pgSql, plus the released reservation on the seller's holding.
+//
+// Offers are bootstrapped through the gateway (the proven c4-otc-scenarios
+// pattern) so the test focuses on the new cancel/reject UI rather than the
+// already-covered create/counter dialogs.
+
+const ADMIN_EMAIL = 'admin@banka.local'
+const ADMIN_PASSWORD = 'Admin123!'
+const SELLER_EMAIL = 'klijent@banka.local'
+const SELLER_PASSWORD = 'Klijent123!'
+const BUYER_EMAIL = 'klijent2@banka.local'
+const BUYER_PASSWORD = 'Klijent123!'
+
+const TICKER = 'AAPL'
+const LISTING_PRICE = 190
+const PUBLIC_QTY = 10
+const OFFER_QTY = 4
+
+function gatewayLogin(email: string, password: string): Cypress.Chainable<string> {
+  return cy
+    .request('POST', '/api/v1/auth/login', { email, password })
+    .then((r) => r.body.accessToken as string)
+}
+
+function loginViaUi(email: string, password: string): void {
+  cy.visit('/login')
+  cy.findByLabelText('Email', { timeout: 30000 }).clear().type(email)
+  cy.findByLabelText('Lozinka').clear().type(password)
+  cy.findByRole('button', { name: /Prijavi se/ }).click()
+  cy.url({ timeout: 10000 }).should('not.include', '/login')
+}
+
+function clearAuth(): void {
+  cy.clearCookies()
+  cy.window().then((w) => {
+    w.sessionStorage.clear()
+    w.localStorage.clear()
+  })
+}
+
+function meUserID(token: string): Cypress.Chainable<string> {
+  return cy
+    .request({ url: '/api/v1/auth/me', headers: { Authorization: `Bearer ${token}` } })
+    .then((r) => (r.body.client?.id ?? r.body.employee?.id) as string)
+}
+
+function findSecurity(token: string, ticker: string) {
+  return cy
+    .request({
+      url: `/api/v1/securities?search=${encodeURIComponent(ticker)}&type=SECURITY_TYPE_STOCK`,
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    .then((r) => {
+      const hit = (r.body.items ?? []).find(
+        (i: { security?: { ticker?: string } }) => i.security?.ticker === ticker,
+      )
+      if (!hit) throw new Error(`security ${ticker} not found`)
+      return {
+        securityId: hit.security.id as string,
+        exchangeMic: (hit.listing?.exchangeMic ?? 'XNYS') as string,
+      }
+    })
+}
+
+function pinListing(adminTok: string, securityId: string, exchangeMic: string, price: number) {
+  return cy.request({
+    method: 'PUT',
+    url: '/api/v1/listings',
+    headers: { Authorization: `Bearer ${adminTok}` },
+    body: {
+      securityId,
+      exchangeMic,
+      price: String(price),
+      ask: String(price + 0.5),
+      bid: String(price - 0.5),
+    },
+  })
+}
+
+function findUsdAccount(token: string, ownerClientId: string) {
+  return cy
+    .request({
+      url: `/api/v1/accounts?ownerClientId=${ownerClientId}`,
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    .then((r) => {
+      const usd = (r.body.accounts ?? []).find(
+        (a: { currency?: string }) => a.currency === 'CURRENCY_USD',
+      ) as { id?: string } | undefined
+      if (!usd?.id) throw new Error(`no USD account for ${ownerClientId}`)
+      return usd.id as string
+    })
+}
+
+function mintBuyerUsd(adminTok: string, buyerId: string, balance = 50000) {
+  return cy.request({
+    method: 'POST',
+    url: '/api/v1/accounts',
+    headers: { Authorization: `Bearer ${adminTok}` },
+    body: {
+      ownerClientId: buyerId,
+      kind: 'ACCOUNT_KIND_PERSONAL_FX',
+      subtype: 'ACCOUNT_SUBTYPE_UNSPECIFIED',
+      currency: 'CURRENCY_USD',
+      name: 'Trgovinski USD',
+      openingBalance: String(balance),
+    },
+  })
+}
+
+function listSellerHolding(token: string, ticker: string) {
+  return cy
+    .request({ url: '/api/v1/portfolio', headers: { Authorization: `Bearer ${token}` } })
+    .then((r) => {
+      const h = (r.body.holdings ?? []).find(
+        (x: { security?: { ticker?: string } }) => x.security?.ticker === ticker,
+      )
+      if (!h) throw new Error(`seller has no ${ticker} holding`)
+      return h as { id: string; reservedCount?: number }
+    })
+}
+
+function setPublicCount(token: string, holdingId: string, count: number) {
+  return cy.request({
+    method: 'PATCH',
+    url: `/api/v1/portfolio/${holdingId}/public-count`,
+    headers: { Authorization: `Bearer ${token}` },
+    body: { publicCount: count },
+  })
+}
+
+// createOffer plants one open thread via the gateway. `lastModifier`
+// controls which party owns the live iteration:
+//   'buyer'  → the buyer created the offer (buyer is originator). The
+//              seller is the counterparty (can reject); the buyer can
+//              cancel.
+//   'seller' → the buyer creates, then the seller counters, so the
+//              seller becomes originator (seller can cancel); the buyer
+//              is the counterparty (can reject).
+function createOffer(
+  buyerTok: string,
+  sellerTok: string,
+  sellerHoldingId: string,
+  buyerUsdId: string,
+  sellerUsdId: string,
+  qty: number,
+  lastModifier: 'buyer' | 'seller',
+): Cypress.Chainable<string> {
+  return cy
+    .request({
+      method: 'POST',
+      url: '/api/v1/otc/offers',
+      headers: { Authorization: `Bearer ${buyerTok}`, 'Idempotency-Key': crypto.randomUUID() },
+      body: {
+        sellerHoldingId,
+        buyerAccountId: buyerUsdId,
+        sellerAccountId: sellerUsdId,
+        quantity: qty,
+        pricePerUnit: '195.00',
+        premium: '10.00',
+        settlementDate: '2026-12-31T00:00:00Z',
+      },
+    })
+    .then((r) => {
+      expect(r.status, 'create offer 200').to.eq(200)
+      const threadId = r.body.threadId as string
+      if (lastModifier === 'buyer') return cy.wrap(threadId)
+      // Seller counters so the seller owns the live iteration.
+      return cy
+        .request({
+          method: 'POST',
+          url: `/api/v1/otc/offers/${threadId}/counter`,
+          headers: { Authorization: `Bearer ${sellerTok}`, 'Idempotency-Key': crypto.randomUUID() },
+          body: {
+            quantity: qty,
+            pricePerUnit: '200.00',
+            premium: '10.00',
+            settlementDate: '2026-12-31T00:00:00Z',
+          },
+        })
+        .then((cr) => {
+          expect(cr.status, 'seller counter 200').to.eq(200)
+          return cy.wrap(threadId)
+        })
+    })
+}
+
+// otcStatus reads the latest iteration's status straight from the DB so
+// we can assert the terminal cancelled/rejected state after the modal
+// closes (ListOTCThreads drops non-open threads).
+function otcStatus(threadId: string): Cypress.Chainable<string> {
+  return cy
+    .pgSql(
+      `SELECT status FROM "trading".otc_offers
+        WHERE thread_id = '${threadId}'
+        ORDER BY created_at DESC LIMIT 1`,
+    )
+    .then((s) => (s as string).trim())
+}
+
+interface Ctx {
+  adminTok: string
+  sellerTok: string
+  buyerTok: string
+  buyerId: string
+  sellerHoldingId: string
+  buyerUsdId: string
+  sellerUsdId: string
+}
+
+function bootstrap(): Cypress.Chainable<Ctx> {
+  return gatewayLogin(ADMIN_EMAIL, ADMIN_PASSWORD).then((adminTok) =>
+    gatewayLogin(SELLER_EMAIL, SELLER_PASSWORD).then((sellerTok) =>
+      gatewayLogin(BUYER_EMAIL, BUYER_PASSWORD).then((buyerTok) =>
+        meUserID(buyerTok).then((buyerId) =>
+          meUserID(sellerTok).then((sellerId) =>
+            findSecurity(adminTok, TICKER).then(({ securityId, exchangeMic }) =>
+              pinListing(adminTok, securityId, exchangeMic, LISTING_PRICE).then(() =>
+                listSellerHolding(sellerTok, TICKER).then((h) =>
+                  setPublicCount(sellerTok, h.id, PUBLIC_QTY).then(() =>
+                    mintBuyerUsd(adminTok, buyerId).then(() =>
+                      findUsdAccount(adminTok, buyerId).then((buyerUsdId) =>
+                        findUsdAccount(sellerTok, sellerId).then((sellerUsdId) => ({
+                          adminTok,
+                          sellerTok,
+                          buyerTok,
+                          buyerId,
+                          sellerHoldingId: h.id,
+                          buyerUsdId,
+                          sellerUsdId,
+                        })),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  )
+}
+
+describe('Celina 4 — OTC offer state machine (cancel / reject)', () => {
+  beforeEach(() => {
+    cy.resetBackend()
+    // Seed's OTC thread fixture (SEED_OTC=0 here, but defensive) bumps
+    // klijent's AAPL reserved_count; zero it so PublicCountEditor's max
+    // (= quantity − reserved) accepts the full publish.
+    cy.pgSql(`UPDATE "trading".portfolio_holdings h
+                 SET reserved_count = 0
+                FROM "trading".securities s
+               WHERE s.id = h.security_id
+                 AND s.ticker = 'AAPL' AND s.type = 'stock'`)
+  })
+
+  it('originator otkazuje svoju otvorenu ponudu → status Otkazana, nestaje iz aktivnih', () => {
+    // Buyer is the originator (created the offer, no counter), so the
+    // buyer sees "Otkaži ponudu" while waiting on the seller.
+    bootstrap().then((ctx) => {
+      createOffer(
+        ctx.buyerTok,
+        ctx.sellerTok,
+        ctx.sellerHoldingId,
+        ctx.buyerUsdId,
+        ctx.sellerUsdId,
+        OFFER_QTY,
+        'buyer',
+      ).then((threadId) => {
+        // Reservation is held while the offer is open.
+        listSellerHolding(ctx.sellerTok, TICKER).then((h) => {
+          expect(h.reservedCount, 'reserved while open').to.eq(OFFER_QTY)
+        })
+
+        clearAuth()
+        loginViaUi(BUYER_EMAIL, BUYER_PASSWORD)
+        cy.visit('/banking/otc/ponude')
+        cy.contains('h1', 'Aktivne ponude', { timeout: 15000 }).should('be.visible')
+
+        // Open the thread modal; the originator's view exposes "Otkaži".
+        cy.get(`[data-cy="otc-thread-${threadId}"]`, { timeout: 15000 }).click()
+        cy.contains(`Pregovaranje — ${TICKER}`, { timeout: 10000 }).should('be.visible')
+        cy.get('[data-cy="otc-cancel"]').should('be.visible').click()
+
+        // Modal closes on success.
+        cy.contains(`Pregovaranje — ${TICKER}`).should('not.exist')
+        // Thread is no longer in the active (open-only) list.
+        cy.get(`[data-cy="otc-thread-${threadId}"]`).should('not.exist')
+
+        // Persisted terminal status = cancelled (rendered as "Otkazana").
+        otcStatus(threadId).then((status) => {
+          expect(status, 'DB status after cancel').to.eq('cancelled')
+        })
+        // Reservation released back to the seller's holding.
+        listSellerHolding(ctx.sellerTok, TICKER).then((h) => {
+          expect(h.reservedCount, 'reservation released on cancel').to.eq(0)
+        })
+      })
+    })
+  })
+
+  it('counterparty odbija najnoviju ponudu → status Odbijena, nestaje iz aktivnih', () => {
+    // Seller counters (becomes originator). The BUYER is now the
+    // counterparty and sees "Odbij ponudu" alongside the counter form.
+    bootstrap().then((ctx) => {
+      createOffer(
+        ctx.buyerTok,
+        ctx.sellerTok,
+        ctx.sellerHoldingId,
+        ctx.buyerUsdId,
+        ctx.sellerUsdId,
+        OFFER_QTY,
+        'seller',
+      ).then((threadId) => {
+        clearAuth()
+        loginViaUi(BUYER_EMAIL, BUYER_PASSWORD)
+        cy.visit('/banking/otc/ponude')
+        cy.contains('h1', 'Aktivne ponude', { timeout: 15000 }).should('be.visible')
+
+        cy.get(`[data-cy="otc-thread-${threadId}"]`, { timeout: 15000 }).click()
+        cy.contains(`Pregovaranje — ${TICKER}`, { timeout: 10000 }).should('be.visible')
+        // Counterparty sees both reject + counter affordances.
+        cy.get('[data-cy="otc-reject"]').should('be.visible').click()
+
+        cy.contains(`Pregovaranje — ${TICKER}`).should('not.exist')
+        cy.get(`[data-cy="otc-thread-${threadId}"]`).should('not.exist')
+
+        otcStatus(threadId).then((status) => {
+          expect(status, 'DB status after reject').to.eq('rejected')
+        })
+        listSellerHolding(ctx.sellerTok, TICKER).then((h) => {
+          expect(h.reservedCount, 'reservation released on reject').to.eq(0)
+        })
+      })
+    })
+  })
+
+  // SKIP (cron): the 3-business-day inactivity sweep (open → expired) is
+  // driven by the trading-service scheduler walking otc_offers.updated_at;
+  // it is not reachable from a single Cypress stack without backdating +
+  // a manual cron tick that the gateway doesn't expose. The drivable
+  // terminal transitions (cancelled / rejected) are covered above.
+})

--- a/cypress/e2e/celina5/interbank-supervisor.cy.ts
+++ b/cypress/e2e/celina5/interbank-supervisor.cy.ts
@@ -1,0 +1,139 @@
+/// <reference types="cypress" />
+
+export {}
+
+// Celina 5 — supervisor/admin inter-bank observability & control portal
+// under /portal/medjubankarske. Three sub-pages:
+//   * index         — "Međubankarske transakcije" (2PC tx status board)
+//   * komunikacija   — "Međubankarska komunikacija" (inbound message audit)
+//   * blokade        — "Blokirane banke" (partner blacklist + manual
+//                       block / unblock)
+//
+// Single-stack coverage: live inter-bank tx + comms data needs a partner
+// bank to round-trip, so for those two pages we assert the page LOADS and
+// renders its empty-state (no 500 / broken route). The blacklist control
+// path is fully local (writes bank.interbank_blacklist), so we drive the
+// manual block → unblock flow end-to-end. We also assert access control:
+// a client is redirected away from the portal section.
+
+const CLIENT_EMAIL = 'klijent@banka.local'
+const CLIENT_PASSWORD = 'Klijent123!'
+
+const PARTNER_ROUTING = '444'
+
+function loginViaUi(email: string, password: string): void {
+  cy.visit('/login')
+  cy.findByLabelText('Email', { timeout: 30000 }).clear().type(email)
+  cy.findByLabelText('Lozinka').clear().type(password)
+  cy.findByRole('button', { name: /Prijavi se/ }).click()
+  cy.url({ timeout: 10000 }).should('not.include', '/login')
+}
+
+function clearAuth(): void {
+  cy.clearCookies()
+  cy.window().then((w) => {
+    w.sessionStorage.clear()
+    w.localStorage.clear()
+  })
+}
+
+describe('Celina 5 — inter-bank supervisor portal', () => {
+  beforeEach(() => {
+    cy.resetBackend()
+  })
+
+  it('transakcije + komunikacija stranice se učitavaju (prazno stanje)', () => {
+    cy.loginAsSupervisor()
+
+    // Transactions board.
+    cy.visit('/portal/medjubankarske')
+    cy.contains('h1', 'Međubankarske transakcije', { timeout: 15000 }).should('be.visible')
+    // No partner traffic yet → empty row, page rendered (no 500).
+    cy.contains('Nema transakcija.', { timeout: 15000 }).should('be.visible')
+
+    // Comms / audit board.
+    cy.visit('/portal/medjubankarske/komunikacija')
+    cy.contains('h1', 'Međubankarska komunikacija', { timeout: 15000 }).should('be.visible')
+    cy.contains('Nema zapisa.', { timeout: 15000 }).should('be.visible')
+
+    // Blacklist board.
+    cy.visit('/portal/medjubankarske/blokade')
+    cy.contains('h1', 'Blokirane banke', { timeout: 15000 }).should('be.visible')
+    cy.contains('Nema blokiranih banaka.', { timeout: 15000 }).should('be.visible')
+  })
+
+  it('blokade: ručno blokira partnera, prikazuje ga, pa odblokira', () => {
+    cy.loginAsSupervisor()
+    cy.visit('/portal/medjubankarske/blokade')
+    cy.contains('h1', 'Blokirane banke', { timeout: 15000 }).should('be.visible')
+    cy.contains('Nema blokiranih banaka.', { timeout: 15000 }).should('be.visible')
+
+    // Manual block via the form.
+    cy.findByPlaceholderText('npr. 444').clear().type(PARTNER_ROUTING)
+    cy.findByPlaceholderText('npr. sumnjiva aktivnost').clear().type('cypress test blokada')
+    cy.contains('button', 'Blokiraj').click()
+
+    // The active blacklist now shows the partner row with our reason and
+    // an "Aktivna blokada" status.
+    cy.contains('tr', PARTNER_ROUTING, { timeout: 15000 }).should('be.visible')
+    cy.contains('tr', PARTNER_ROUTING).should('contain', 'cypress test blokada')
+    cy.contains('tr', PARTNER_ROUTING).should('contain', 'Aktivna blokada')
+    // Cross-check the DB write landed.
+    cy.pgSql(
+      `SELECT active::text FROM "bank".interbank_blacklist
+        WHERE sender_routing_number = ${PARTNER_ROUTING}`,
+    ).then((s) => {
+      expect((s as string).trim(), 'blacklist row active').to.eq('true')
+    })
+
+    // Unblock → the row leaves the active list (default view is
+    // active-only). The audit row is retained (active=false) but hidden
+    // until "Prikaži i istoriju" is checked.
+    cy.contains('tr', PARTNER_ROUTING).contains('button', 'Odblokiraj').click()
+    cy.contains('Nema blokiranih banaka.', { timeout: 15000 }).should('be.visible')
+
+    // History view surfaces the now-inactive row as "Odblokirana".
+    cy.contains('label', 'Prikaži i istoriju').find('input[type="checkbox"]').check()
+    cy.contains('tr', PARTNER_ROUTING, { timeout: 15000 }).should('contain', 'Odblokirana')
+
+    cy.pgSql(
+      `SELECT active::text FROM "bank".interbank_blacklist
+        WHERE sender_routing_number = ${PARTNER_ROUTING}`,
+    ).then((s) => {
+      expect((s as string).trim(), 'blacklist row deactivated').to.eq('false')
+    })
+  })
+
+  it('blokade: prikazuje unapred zasejanu blokadu (pgSql fixture)', () => {
+    // Plant an active blacklist row directly so the list renders a row
+    // independent of the manual-block UI path.
+    cy.pgSql(
+      `INSERT INTO "bank".interbank_blacklist
+         (sender_routing_number, reason, blocked_by, active)
+       VALUES (555, 'zasejana sumnjiva aktivnost', 'system', true)
+       ON CONFLICT (sender_routing_number)
+       DO UPDATE SET active = true, reason = excluded.reason,
+                     blocked_by = excluded.blocked_by, unblocked_at = null`,
+    )
+
+    cy.loginAsSupervisor()
+    cy.visit('/portal/medjubankarske/blokade')
+    cy.contains('h1', 'Blokirane banke', { timeout: 15000 }).should('be.visible')
+    cy.contains('tr', '555', { timeout: 15000 })
+      .should('contain', 'zasejana sumnjiva aktivnost')
+      .and('contain', 'Aktivna blokada')
+    // Auto-blocks (blocked_by='system') render as "Automatski".
+    cy.contains('tr', '555').should('contain', 'Automatski')
+  })
+
+  it('access control: klijent ne može da pristupi inter-bank portalu', () => {
+    clearAuth()
+    loginViaUi(CLIENT_EMAIL, CLIENT_PASSWORD)
+    // A client hitting the portal section is redirected out (portal layer
+    // sends clients to /banking; the route guard also fires).
+    cy.visit('/portal/medjubankarske')
+    cy.url({ timeout: 10000 }).should('not.include', '/medjubankarske')
+    cy.visit('/portal/medjubankarske/blokade')
+    cy.url({ timeout: 10000 }).should('not.include', '/medjubankarske')
+  })
+})

--- a/cypress/e2e/celina5/scheduled-interbank.cy.ts
+++ b/cypress/e2e/celina5/scheduled-interbank.cy.ts
@@ -1,0 +1,183 @@
+/// <reference types="cypress" />
+
+export {}
+
+// Celina 5 (todoSpec "Scheduled/periodic inter-bank payments") — the
+// client surface at /banking/placanja/inostrane-zakazane. A client
+// schedules a cross-bank payment (dest bank code + 18-digit dest account,
+// amount, cadence, optional start date), the row appears as Aktivna, and
+// can be paused / resumed / cancelled.
+//
+// Single-stack coverage: this tests the LOCAL side only — create / list /
+// pause / resume / cancel + validation. The actual periodic execution
+// (the trading-scheduled-interbank daily sweep) drives the cross-bank 2PC
+// path against a PARTNER bank and is therefore cron + second-stack
+// driven; cypress/interbank/* covers the round-trip with a dual stack.
+// SKIP (cron/partner): periodic execution + partner round-trip — see note
+// at the end.
+//
+// Account-number checksum is the spec p.checksum algorithm sum(digits)%11;
+// the FE only gates length===18, the backend enforces the checksum + the
+// "account belongs to bank" prefix + future-date rules, surfacing a
+// Serbian ErrorBanner on reject.
+
+const DEST_BANK = '222'
+
+// validAcct builds an 18-digit account number that starts with `prefix`
+// and whose digit sum is divisible by 11 (the cross-bank checksum). We
+// fill the middle with zeros and tune the final digits so sum % 11 == 0.
+function validAcct(prefix: string): string {
+  const head = (prefix + '0'.repeat(18)).slice(0, 16) // 16 digits, rest zero
+  const headSum = head.split('').reduce((a, c) => a + Number(c), 0)
+  // Two trailing digits chosen so (headSum + tail) % 11 == 0.
+  const need = (11 - (headSum % 11)) % 11 // 0..10
+  const tail = String(need).padStart(2, '0') // <= 10 → "00".."10"
+  const num = head + tail
+  // Sanity: 18 digits, divisible by 11.
+  const sum = num.split('').reduce((a, c) => a + Number(c), 0)
+  if (num.length !== 18 || sum % 11 !== 0) {
+    throw new Error(`validAcct produced bad number ${num} (sum ${sum})`)
+  }
+  return num
+}
+
+// invalidAcct: 18 digits, right prefix, but digit sum NOT divisible by 11.
+function invalidAcct(prefix: string): string {
+  const base = validAcct(prefix)
+  // Bump the last digit by 1 (mod 10) so the checksum breaks while length
+  // + prefix stay valid. If that lands back on a multiple of 11, bump
+  // again.
+  let n = base
+  for (let i = 0; i < 11; i++) {
+    const last = Number(n[17])
+    n = n.slice(0, 17) + String((last + 1) % 10)
+    const sum = n.split('').reduce((a, c) => a + Number(c), 0)
+    if (sum % 11 !== 0) return n
+  }
+  throw new Error('could not derive invalid checksum number')
+}
+
+function futureDate(daysAhead: number): string {
+  const d = new Date()
+  d.setDate(d.getDate() + daysAhead)
+  return d.toISOString().slice(0, 10)
+}
+
+function pastDate(daysAgo: number): string {
+  const d = new Date()
+  d.setDate(d.getDate() - daysAgo)
+  return d.toISOString().slice(0, 10)
+}
+
+describe('Celina 5 — scheduled cross-bank payments (local side)', () => {
+  beforeEach(() => {
+    cy.resetBackend()
+  })
+
+  it('kreira mesečnu zakazanu uplatu, pa pauza / nastavi / otkaži', () => {
+    const dest = validAcct(DEST_BANK)
+
+    cy.loginAsClient()
+    cy.visit('/banking/placanja/inostrane-zakazane')
+    cy.contains('h1', 'Zakazane inostrane uplate', { timeout: 15000 }).should('be.visible')
+    // Starts empty (SEED has no scheduled rows).
+    cy.get('[data-cy="scheduled-interbank-empty"]', { timeout: 15000 }).should('be.visible')
+
+    // The source-account select auto-populates from the client's active
+    // accounts; pick the first non-placeholder option.
+    cy.get('[data-cy="scheduled-interbank-account"]', { timeout: 15000 })
+      .find('option')
+      .eq(1)
+      .then(($opt) => {
+        cy.get('[data-cy="scheduled-interbank-account"]').select($opt.val() as string)
+      })
+    cy.get('[data-cy="scheduled-interbank-bank"]').clear().type(DEST_BANK)
+    cy.get('[data-cy="scheduled-interbank-dest"]').clear().type(dest)
+    cy.get('[data-cy="scheduled-interbank-amount"]').clear().type('400')
+    cy.get('[data-cy="scheduled-interbank-cadence"]').select('MONTHLY')
+    cy.get('[data-cy="scheduled-interbank-date"]').type(futureDate(7))
+    cy.get('[data-cy="scheduled-interbank-submit"]').should('not.be.disabled').click()
+
+    // The new row lands as Aktivna in "Moje zakazane uplate".
+    cy.get('[data-cy="scheduled-interbank-list"]', { timeout: 15000 }).should('exist')
+    cy.get('[data-cy="scheduled-interbank-item"]').should('have.length', 1)
+    cy.get('[data-cy="scheduled-interbank-item-dest"]').should('contain', dest)
+    cy.get('[data-cy="scheduled-interbank-item-status"]').should('contain', 'Aktivna')
+
+    // Pause → "Pauzirana"; resume → "Aktivna".
+    cy.get('[data-cy="scheduled-interbank-pause"]').click()
+    cy.get('[data-cy="scheduled-interbank-item-status"]', { timeout: 15000 }).should(
+      'contain',
+      'Pauzirana',
+    )
+    cy.get('[data-cy="scheduled-interbank-resume"]').click()
+    cy.get('[data-cy="scheduled-interbank-item-status"]', { timeout: 15000 }).should(
+      'contain',
+      'Aktivna',
+    )
+
+    // Cancel → the row drops out of the list (cancel deactivates +
+    // ListScheduledInterbankPaymentsByUser excludes cancelled rows).
+    cy.get('[data-cy="scheduled-interbank-cancel"]').click()
+    cy.get('[data-cy="scheduled-interbank-empty"]', { timeout: 15000 }).should('be.visible')
+  })
+
+  it('odbija nevažeći checksum destinacijskog računa', () => {
+    const badAcct = invalidAcct(DEST_BANK)
+
+    cy.loginAsClient()
+    cy.visit('/banking/placanja/inostrane-zakazane')
+    cy.contains('h1', 'Zakazane inostrane uplate', { timeout: 15000 }).should('be.visible')
+
+    cy.get('[data-cy="scheduled-interbank-account"]', { timeout: 15000 })
+      .find('option')
+      .eq(1)
+      .then(($opt) => {
+        cy.get('[data-cy="scheduled-interbank-account"]').select($opt.val() as string)
+      })
+    cy.get('[data-cy="scheduled-interbank-bank"]').clear().type(DEST_BANK)
+    // 18 digits so the FE submit gate opens, but a broken checksum.
+    cy.get('[data-cy="scheduled-interbank-dest"]').clear().type(badAcct)
+    cy.get('[data-cy="scheduled-interbank-amount"]').clear().type('400')
+    cy.get('[data-cy="scheduled-interbank-cadence"]').select('MONTHLY')
+    cy.get('[data-cy="scheduled-interbank-date"]').type(futureDate(7))
+    cy.get('[data-cy="scheduled-interbank-submit"]').should('not.be.disabled').click()
+
+    // Backend rejects on the checksum; the Serbian error surfaces and no
+    // row is created.
+    cy.contains(/checksum/i, { timeout: 15000 }).should('be.visible')
+    cy.get('[data-cy="scheduled-interbank-empty"]').should('be.visible')
+  })
+
+  it('odbija datum početka u prošlosti', () => {
+    const dest = validAcct(DEST_BANK)
+
+    cy.loginAsClient()
+    cy.visit('/banking/placanja/inostrane-zakazane')
+    cy.contains('h1', 'Zakazane inostrane uplate', { timeout: 15000 }).should('be.visible')
+
+    cy.get('[data-cy="scheduled-interbank-account"]', { timeout: 15000 })
+      .find('option')
+      .eq(1)
+      .then(($opt) => {
+        cy.get('[data-cy="scheduled-interbank-account"]').select($opt.val() as string)
+      })
+    cy.get('[data-cy="scheduled-interbank-bank"]').clear().type(DEST_BANK)
+    cy.get('[data-cy="scheduled-interbank-dest"]').clear().type(dest)
+    cy.get('[data-cy="scheduled-interbank-amount"]').clear().type('400')
+    cy.get('[data-cy="scheduled-interbank-cadence"]').select('ONCE')
+    cy.get('[data-cy="scheduled-interbank-date"]').type(pastDate(5))
+    cy.get('[data-cy="scheduled-interbank-submit"]').should('not.be.disabled').click()
+
+    // Backend rejects: "datum početka mora biti u budućnosti".
+    cy.contains(/budućnosti/i, { timeout: 15000 }).should('be.visible')
+    cy.get('[data-cy="scheduled-interbank-empty"]').should('be.visible')
+  })
+
+  // SKIP (cron/partner): the periodic execution of a scheduled payment is
+  // run by the trading-scheduled-interbank daily sweep, which drives the
+  // cross-bank 2PC SubmitCrossBankPayment against a partner bank. That
+  // requires a second bank stack + a cron tick neither of which a single
+  // Cypress stack exposes. The dual-stack round-trip is covered by
+  // cypress/interbank/cross-bank-payments.cy.ts.
+})


### PR DESCRIPTION
Adds 14 live-backend Cypress specs covering the new todoSpec features (34 tests, all green against the rebuilt stack):

- C1: lockout (S7-11), audit-log (S40-46)
- C2: scheduled-payments, notifications (S19), quick-approve (S12)
- C3: watchlist (S35-39), price-alerts (S26-29), dca (S47-53), forex-forwards, dividends (S59)
- C4: otc-offer-actions (cancel/reject), fund-dividends (S69-72)
- C5: scheduled-interbank, interbank-supervisor (blacklist/audit/status)

Cron/partner-driven outcomes are asserted via planted DB state or marked SKIP (backend unit/integration covers the computation). Writing these found a real backend bug (forex-forward spread editor 403/400 for supervisors → fixed in Banka-3-Backend PR #328).

🤖 Generated with [Claude Code](https://claude.com/claude-code)