### PR TITLE
test(cypress): isolate interbank-supervisor spec (truncate interbank tables)

### DIFF
--- a/cypress/e2e/celina5/interbank-supervisor.cy.ts
+++ b/cypress/e2e/celina5/interbank-supervisor.cy.ts
@@ -40,6 +40,14 @@ function clearAuth(): void {
 describe('Celina 5 — inter-bank supervisor portal', () => {
   beforeEach(() => {
     cy.resetBackend()
+    // resetBackend's truncate list predates the inter-bank tables, so
+    // blacklist / protocol rows leak across specs and runs and break the
+    // empty-state assertions below. Clear them explicitly.
+    cy.pgSql(
+      'truncate "bank".interbank_blacklist, "bank".interbank_partner_failures, ' +
+        '"bank".interbank_protocol_messages, "bank".interbank_protocol_transactions ' +
+        'restart identity cascade',
+    )
   })
 
   it('transakcije + komunikacija stranice se učitavaju (prazno stanje)', () => {


### PR DESCRIPTION
The interbank-supervisor spec asserts empty-state on the blacklist/transactions/comms boards, but resetBackend never truncates the inter-bank tables, so rows leaked across runs and broke those assertions in the full suite. Adds a beforeEach truncate of the 4 interbank tables. Passes 4/4 in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)