### PR TITLE
test(cypress): fix login (live) + c4-funds S30 (client-side sort)

### DIFF
--- a/cypress/e2e/celina1/login.cy.ts
+++ b/cypress/e2e/celina1/login.cy.ts
@@ -7,23 +7,15 @@
 
 describe('Celina 1 — autentifikacija', () => {
   it('1: uspešno logovanje zaposlenog', () => {
-    cy.intercept('POST', '/api/v1/auth/login', {
-      statusCode: 200,
-      body: {
-        accessToken: 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJlbXAtMSIsInBlcm1zIjpbImFkbWluIl19.dummy',
-        accessExpiresIn: 900,
-        userId: 'emp-1',
-        userKind: 'employee',
-        permissions: ['admin'],
-      },
-    }).as('login')
-
+    // Live login against the seeded bootstrap admin. A canned mock here is
+    // fragile: a dummy access token 401s on the post-login dashboard calls
+    // and the axios refresh-then-logout path bounces back to /login. The
+    // real backend issues a valid token so the redirect sticks.
     cy.visit('/login')
-    cy.findByLabelText('Email').type('marko@banka.rs')
-    cy.findByLabelText('Lozinka').type('marko123')
+    cy.findByLabelText('Email', { timeout: 30000 }).type('admin@banka.local')
+    cy.findByLabelText('Lozinka').type('Admin123!')
     cy.findByRole('button', { name: /Prijavi se/ }).click()
-    cy.wait('@login')
-    cy.url().should('not.include', '/login')
+    cy.url({ timeout: 30000 }).should('not.include', '/login')
   })
 
   it('2: pogrešna lozinka prikazuje "Neispravni kredencijali"', () => {

--- a/cypress/e2e/celina4/c4-funds-scenarios.cy.ts
+++ b/cypress/e2e/celina4/c4-funds-scenarios.cy.ts
@@ -165,16 +165,18 @@ describe('Celina 4 — Investicioni fondovi: pristup i prikaz (S29-S32)', () => 
     cy.contains('5.000').should('exist')
   })
 
-  it('S30 — filter/sort izaziva re-fetch sa odgovarajućim query parametrima', () => {
+  it('S30 — sort po koloni preuređuje listu (klijentsko sortiranje)', () => {
     clearAuth()
     loginViaUi(CLIENT_EMAIL, CLIENT_PASSWORD)
-    cy.intercept('GET', '/api/v1/funds**').as('funds')
     cy.visit('/banking/fondovi')
-    cy.wait('@funds', { timeout: 15000 })
-    cy.get('[data-cy="funds-sort"]').select('total_value')
-    cy.get('[data-cy="funds-order"]').select('desc')
-    // Last @funds intercept must include sort=total_value + order=desc.
-    cy.wait('@funds').its('request.url').should('match', /sort=total_value/)
+    // Funds discovery now sorts CLIENT-SIDE: the list is fetched once with
+    // a stable order and every column header toggles the sort in place
+    // (no per-sort re-fetch). Clicking the "vrednost" header sorts by
+    // total_value desc, clicking again flips to asc.
+    cy.get('[data-cy="funds-sort-total-value"]', { timeout: 15000 }).should('be.visible').click()
+    cy.get('[data-cy="funds-sort-total-value"]').should('have.attr', 'data-cy-active', 'desc')
+    cy.get('[data-cy="funds-sort-total-value"]').click()
+    cy.get('[data-cy="funds-sort-total-value"]').should('have.attr', 'data-cy-active', 'asc')
   })
 
   it('S31 — klijent otvara detalj fonda i vidi sva propisana polja', () => {


### PR DESCRIPTION
Two pre-existing spec fixes validated green in isolation:
- `login` test 1 → live backend login (canned dummy-token mock bounced to /login on post-login 401s). 3/3.
- `c4-funds-scenarios` S30 → funds sort is now client-side via column headers; assert the header toggles `data-cy-active` instead of the removed `sort=total_value` re-fetch. 19/19.

Part of the Cypress triage; `interbank-supervisor` isolation fix already merged (#291).

🤖 Generated with [Claude Code](https://claude.com/claude-code)