### PR TITLE
test(cypress): option-exercise qty=1 (dialog defaults to full position)

### DIFF
--- a/cypress/e2e/celina3/option-exercise.cy.ts
+++ b/cypress/e2e/celina3/option-exercise.cy.ts
@@ -67,8 +67,10 @@ describe('Celina 3 (live) — agent iskorišćava ITM CALL', () => {
     cy.contains('Iskoristi opciju AAPL-C-190').should('be.visible')
     cy.contains('In the money').should('be.visible')
 
-    // Default qty=1; one contract of size 100 ⇒ 100 underlying shares
-    // bought at strike 190.00.
+    // The partial-exercise dialog (spec p.61.d) defaults to the FULL held
+    // position, so dial it down to 1 — one contract of size 100 ⇒ 100
+    // underlying shares bought at strike 190.00.
+    cy.get('[data-cy="exercise-qty"]').clear().type('1')
     cy.get('[data-cy="exercise-confirm"]').click()
 
     // Dialog closes on success.


### PR DESCRIPTION
The partial-option-exercise feature made the exercise dialog default to the FULL held position; the pre-existing spec assumed the old default of 1 and expected qty 5→4 (it was exercising all 5). Set the qty input to 1 explicitly. 2/2 green in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)